### PR TITLE
Always default to multisig when encoding == 'auto'

### DIFF
--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -329,10 +329,7 @@ def construct (db, tx_info, encoding='auto',
     # Data encoding methods (choose and validate).
     if data:
         if encoding == 'auto':
-            if len(data) <= config.OP_RETURN_MAX_SIZE:
-                encoding = 'opreturn'
-            else:
-                encoding = 'multisig'
+            encoding = 'multisig'
         elif encoding not in ('pubkeyhash', 'multisig', 'opreturn'):
             raise exceptions.TransactionError('Unknown encoding‐scheme.')
 


### PR DESCRIPTION
In my tests this fixes https://github.com/CounterpartyXCP/counterwallet/issues/730.
Probably useful as workaround.