### PR TITLE
custom_inputs parameter for controlling exact utxos to use in transactions

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -71,7 +71,7 @@ API_TRANSACTIONS = ['bet', 'broadcast', 'btcpay', 'burn', 'cancel',
 COMMONS_ARGS = ['encoding', 'fee_per_kb', 'regular_dust_size',
                 'multisig_dust_size', 'op_return_value', 'pubkey',
                 'allow_unconfirmed_inputs', 'fee', 'fee_provided',
-                'unspent_tx_hash']
+                'unspent_tx_hash','custom_inputs']
 
 API_MAX_LOG_SIZE = 10 * 1024 * 1024 #max log size of 20 MB before rotation (make configurable later)
 API_MAX_LOG_COUNT = 10
@@ -270,7 +270,7 @@ def compose_transaction(db, name, params,
                         allow_unconfirmed_inputs=False,
                         fee=None,
                         fee_provided=0,
-                        unspent_tx_hash=None):
+                        unspent_tx_hash=None, custom_inputs=None):
     """Create and return a transaction."""
 
     # Get provided pubkeys.
@@ -313,7 +313,7 @@ def compose_transaction(db, name, params,
                                         allow_unconfirmed_inputs=allow_unconfirmed_inputs,
                                         exact_fee=fee,
                                         fee_provided=fee_provided,
-                                        unspent_tx_hash=unspent_tx_hash)
+                                        unspent_tx_hash=unspent_tx_hash, custom_inputs=custom_inputs)
     # except:
         # import traceback
         # traceback.print_exc()

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -392,7 +392,7 @@ def construct (db, tx_info, encoding='auto',
     # Get inputs.
     multisig_inputs = not data
 
-    use_inputs = custom_inputs
+    use_inputs = custom_inputs # Array of UTXOs, as retrieved by listunspent function from bitcoind
     if custom_inputs is None:
         if unspent_tx_hash is not None:
             unspent = backend.get_unspent_txouts(source, unconfirmed=allow_unconfirmed_inputs, unspent_tx_hash=unspent_tx_hash, multisig_inputs=multisig_inputs)

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -14,7 +14,7 @@ import time
 import decimal
 import logging
 logger = logging.getLogger(__name__)
-
+import pprint
 import requests
 from Crypto.Cipher import ARC4
 from bitcoin.core.script import CScript
@@ -284,7 +284,7 @@ def construct (db, tx_info, encoding='auto',
                multisig_dust_size=config.DEFAULT_MULTISIG_DUST_SIZE,
                op_return_value=config.DEFAULT_OP_RETURN_VALUE,
                exact_fee=None, fee_provided=0, provided_pubkeys=None,
-               allow_unconfirmed_inputs=False, unspent_tx_hash=None):
+               allow_unconfirmed_inputs=False, unspent_tx_hash=None, custom_inputs=None):
 
     (source, destination_outputs, data) = tx_info
 
@@ -392,20 +392,25 @@ def construct (db, tx_info, encoding='auto',
 
     # Get inputs.
     multisig_inputs = not data
-    if unspent_tx_hash is not None:
-        unspent = backend.get_unspent_txouts(source, unconfirmed=allow_unconfirmed_inputs, unspent_tx_hash=unspent_tx_hash, multisig_inputs=multisig_inputs)
-    else:
-        unspent = backend.get_unspent_txouts(source, unconfirmed=allow_unconfirmed_inputs, multisig_inputs=multisig_inputs)
 
-    unspent = backend.sort_unspent_txouts(unspent)
-    logger.debug('Sorted UTXOs: {}'.format([print_coin(coin) for coin in unspent]))
+    use_inputs = custom_inputs
+    if custom_inputs is None:
+        if unspent_tx_hash is not None:
+            unspent = backend.get_unspent_txouts(source, unconfirmed=allow_unconfirmed_inputs, unspent_tx_hash=unspent_tx_hash, multisig_inputs=multisig_inputs)
+        else:
+            unspent = backend.get_unspent_txouts(source, unconfirmed=allow_unconfirmed_inputs, multisig_inputs=multisig_inputs)
+
+        unspent = backend.sort_unspent_txouts(unspent)
+        logger.debug('Sorted UTXOs: {}'.format([print_coin(coin) for coin in unspent]))
+        use_inputs = unspent
+
 
     inputs = []
     btc_in = 0
     change_quantity = 0
     sufficient_funds = False
     final_fee = fee_per_kb
-    for coin in unspent:
+    for coin in use_inputs:
         logger.debug('New input: {}'.format(print_coin(coin)))
         inputs.append(coin)
         btc_in += round(coin['amount'] * config.UNIT)

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -14,7 +14,6 @@ import time
 import decimal
 import logging
 logger = logging.getLogger(__name__)
-import pprint
 import requests
 from Crypto.Cipher import ARC4
 from bitcoin.core.script import CScript


### PR DESCRIPTION
expects an array of same data as retrieved by bitcoind's listunspent() function