### PR TITLE
NodeJS-style logging filter

### DIFF
--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -174,6 +174,8 @@ def sendrawtransaction(tx_hex):
 
 GETRAWTRANSACTION_MAX_RETRIES=2
 def getrawtransaction_batch(txhash_list, verbose=False, _retry=0):
+    _logger = logger.getChild("getrawtransaction_batch")
+
     if len(txhash_list) > config.BACKEND_RAW_TRANSACTIONS_CACHE_SIZE:
         #don't try to load in more than BACKEND_RAW_TRANSACTIONS_CACHE_SIZE entries in a single call
         txhash_list_chunks = util.chunkify(txhash_list, config.BACKEND_RAW_TRANSACTIONS_CACHE_SIZE)
@@ -206,7 +208,7 @@ def getrawtransaction_batch(txhash_list, verbose=False, _retry=0):
     for tx_hash in txhash_list.difference(noncached_txhashes):
         raw_transactions_cache.refresh(tx_hash)
 
-    logger.debug("getrawtransaction_batch: txhash_list size: {} / raw_transactions_cache size: {} / # getrawtransaction calls: {}".format(
+    _logger.debug("getrawtransaction_batch: txhash_list size: {} / raw_transactions_cache size: {} / # getrawtransaction calls: {}".format(
         len(txhash_list), len(raw_transactions_cache), len(payload)))
 
     # populate cache
@@ -230,7 +232,7 @@ def getrawtransaction_batch(txhash_list, verbose=False, _retry=0):
             else:
                 result[tx_hash] = raw_transactions_cache[tx_hash]['hex']
         except KeyError as e: #shows up most likely due to finickyness with addrindex not always returning results that we need...
-            logger.warning("tx missing in rawtx cache: {} -- txhash_list size: {}, hash: {} / raw_transactions_cache size: {} / # rpc_batch calls: {} / txhash in noncached_txhashes: {} / txhash in txhash_list: {} -- list {}".format(
+            _logger.warning("tx missing in rawtx cache: {} -- txhash_list size: {}, hash: {} / raw_transactions_cache size: {} / # rpc_batch calls: {} / txhash in noncached_txhashes: {} / txhash in txhash_list: {} -- list {}".format(
                 e, len(txhash_list), hashlib.md5(json.dumps(list(txhash_list)).encode()).hexdigest(), len(raw_transactions_cache), len(payload),
                 tx_hash in noncached_txhashes, tx_hash in txhash_list, list(txhash_list.difference(noncached_txhashes)) ))
             if  _retry < GETRAWTRANSACTION_MAX_RETRIES: #try again

--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -79,7 +79,7 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
                 rpc_host=None, rpc_port=None,
                 rpc_user=None, rpc_password=None,
                 rpc_no_allow_cors=False,
-                force=False, verbose=False,
+                force=False, verbose=False, console_logfilter=None,
                 requests_timeout=config.DEFAULT_REQUESTS_TIMEOUT,
                 rpc_batch_size=config.DEFAULT_RPC_BATCH_SIZE,
                 check_asset_conservation=config.DEFAULT_CHECK_ASSET_CONSERVATION,
@@ -137,7 +137,7 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
 
     # Set up logging.
     root_logger = logging.getLogger()    # Get root logger.
-    log.set_up(root_logger, verbose=verbose, logfile=config.LOG)
+    log.set_up(root_logger, verbose=verbose, logfile=config.LOG, console_logfilter=console_logfilter)
     # Log unhandled errors.
     def handle_exception(exc_type, exc_value, exc_traceback):
         logger.error("Unhandled Exception", exc_info=(exc_type, exc_value, exc_traceback))


### PR DESCRIPTION
NodeJS-style logging, ie:
`filters="*,-counterpartylib.lib,counterpartylib.lib.api"`

will log:
 - counterpartycli.server
 - counterpartylib.lib.api

but will not log:
 - counterpartylib.lib
 - counterpartylib.lib.backend.addrindex

-------------------

This will make it possible again to use the `--verbose` of `counterparty-server` without getting HUGE amount of spam:
`OUNTERPARTY_LOGGING="*,-counterpartylib.lib.backend.addrindex.getrawtransaction_batch" counterparty-server --testnet --verbose start`

I haven't done python for a while and before I never needed anything like this, but the NodeJS way of doing logging with a list of filters is kinda nice imo.

https://github.com/CounterpartyXCP/counterparty-cli/pull/68 provides the `console_logfilter` from `env.COUNTERPARTY_LOGGING`.