### PR TITLE
backend should keep cache of full mempool.

### DIFF
--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -1185,19 +1185,21 @@ def follow(db):
             # a fake block, a fake transaction, capture the generated messages,
             # and then save those messages.
             # Every transaction in mempool is parsed independently. (DB is rolled back after each one.)
-            mempool = []
+            xcp_mempool = []
             raw_mempool = backend.getrawmempool()
             for tx_hash in raw_mempool:
                 # If already in mempool, copy to new one.
                 if tx_hash in old_mempool_hashes:
                     for message in old_mempool:
                         if message['tx_hash'] == tx_hash:
-                            mempool.append((tx_hash, message))
+                            xcp_mempool.append((tx_hash, message))
 
-                # If already skipped, skip it again.
-                elif tx_hash not in not_supported:
+                # If not a supported XCP transaction, skip.
+                elif tx_hash in not_supported:
+                    pass
 
-                    # Else: list, parse and save it.
+                # Else: list, parse and save it.
+                else:
                     try:
                         with db:
                             # List the fake block.
@@ -1239,7 +1241,7 @@ def follow(db):
                             # Save transaction and side‐effects in memory.
                             cursor.execute('''SELECT * FROM messages WHERE block_index = ?''', (config.MEMPOOL_BLOCK_INDEX,))
                             for message in list(cursor):
-                                mempool.append((tx_hash, message))
+                                xcp_mempool.append((tx_hash, message))
 
                             # Rollback.
                             raise MempoolError
@@ -1249,18 +1251,23 @@ def follow(db):
             # Re‐write mempool messages to database.
             with db:
                 cursor.execute('''DELETE FROM mempool''')
-                for message in mempool:
+                for message in xcp_mempool:
                     tx_hash, new_message = message
                     new_message['tx_hash'] = tx_hash
                     cursor.execute('''INSERT INTO mempool VALUES(:tx_hash, :command, :category, :bindings, :timestamp)''', (new_message))
                     
-            backend.refresh_unconfirmed_transactions_cache([tx_hash for tx_hash, message in mempool])
+            refresh_start_time = time.time()
+            backend.refresh_unconfirmed_transactions_cache(raw_mempool)
+            refresh_time = time.time() - refresh_start_time
 
             elapsed_time = time.time() - start_time
             sleep_time = config.BACKEND_POLL_INTERVAL - elapsed_time if elapsed_time <= config.BACKEND_POLL_INTERVAL else 0
 
-            logger.debug('Refresh mempool: %s CP txs seen, out of %s total entries (took %ss, next refresh in %ss)' % (
-                len(mempool), len(raw_mempool), "{:.2f}".format(elapsed_time, 3), "{:.2f}".format(sleep_time, 3)))
+            logger.debug('Refresh mempool: %s XCP txs seen, out of %s total entries (took %ss (%ss was backend refresh), next refresh in %ss)' % (
+                len(xcp_mempool), len(raw_mempool),
+                "{:.2f}".format(elapsed_time, 3),
+                "{:.2f}".format(refresh_time, 3),
+                "{:.2f}".format(sleep_time, 3)))
 
             # Wait
             db.wal_checkpoint(mode=apsw.SQLITE_CHECKPOINT_PASSIVE)


### PR DESCRIPTION
fixes https://github.com/CounterpartyXCP/counterparty-lib/issues/811 (and indirectly also https://github.com/CounterpartyXCP/counterwallet/issues/626)

#### Easiest way to reproduce
Send BTC twice from the same address before a block is found.

--------------

when doing `backend.get_unspent_txouts(unconfirmed=true)` the backend uses it's in-memory `unconfirmed_transactions_cache` instead of the `searchrawtransactions` from bitcoind, because bitcoind `searchrawtransactions` only works for confirmed transactions.

A while back (I think here https://github.com/CounterpartyXCP/counterparty-lib/commit/db052758b07eda6bcbf52ec9fce19d2be5030a99) some optimizations made it so that `backend.refresh_unconfirmed_transactions_cache` is only called for XCP related transactions, as a result any unconfirmed plain old BTC transactions are ignored and can't be spend until confirmed.

This PR changes the behaviory again to call `backend.refresh_unconfirmed_transactions_cache` with all the mempool TXs and optimizes `backend.refresh_unconfirmed_transactions_cache` to avoid calling `extract_addresses` more than once for a transaction.

----------

The biggest danger here is that we'll be storing more data in memory, instead of only keeping the raw transactions for unconfirmed counterparty-related transactions we're storing all raw transactions in memory.

I think this is a good solution, to only store the tx_hash in the unconfirmed_transactions_cache and the extracted addresses and do `getrawtransaction` calls once the actual raw transaction is needed (when it's actually being spend from).

---------

bitcoin core v0.12.0 will include mempool limiting, so we'll be able to piggyback on that and won't have to build anything to limit our own mempool.

see bitcoin/bitcoin#6722