### PR TITLE
enable wildcard matching for `--function`, eg `--function=blocks.*`

### DIFF
--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -291,7 +291,18 @@ def vector_to_args(vector, functions=[]):
                     error = params['error']
                 if 'records' in params:
                     records = params['records']
-                if functions == [] or (tx_name + '.' + method) in functions:
+
+                test_name = (tx_name + '.' + method)
+
+                add_test = not functions or not len(functions)
+                add_test = add_test or test_name in functions
+
+                if not add_test:
+                    for function in filter(lambda f: f[-1:] == "*", functions):
+                        if test_name.find(function[:-1], 0) == 0:
+                            add_test = True
+
+                if add_test:
                     args.append((tx_name, method, params['in'], outputs, error, records))
     return args
 


### PR DESCRIPTION
makes life a little easier when you're developing and just want to run a few specific tests, but more then just 1 or 2 xD