### PR TITLE
pass `comment` along to `test_vector` so that it shows up for failures.

### DIFF
--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -33,7 +33,7 @@ def pytest_generate_tests(metafunc):
     """Generate all py.test cases. Checks for different types of tests and creates proper context."""
     if metafunc.function.__name__ == 'test_vector':
         args = util_test.vector_to_args(UNITTEST_VECTOR, pytest.config.option.function)
-        metafunc.parametrize('tx_name, method, inputs, outputs, error, records', args)
+        metafunc.parametrize('tx_name, method, inputs, outputs, error, records, comment', args)
     elif metafunc.function.__name__ == 'test_scenario':
         args = []
         for scenario_name in INTEGRATION_SCENARIOS:

--- a/counterpartylib/test/unit_test.py
+++ b/counterpartylib/test/unit_test.py
@@ -40,12 +40,12 @@ def server_db(request):
     request.addfinalizer(lambda: cursor.execute('''ROLLBACK'''))
     return db
 
-def test_vector(tx_name, method, inputs, outputs, error, records, server_db):
+def test_vector(tx_name, method, inputs, outputs, error, records, comment, server_db):
     """Test the outputs of unit test vector. If testing parse, execute the transaction data on test db."""
     if method == 'parse':
         util_test.insert_transaction(inputs[0], server_db)
         inputs += (inputs[0]['data'][4:],) # message arg
-    util_test.check_outputs(tx_name, method, inputs, outputs, error, records, server_db)
+    util_test.check_outputs(tx_name, method, inputs, outputs, error, records, comment, server_db)
 
 # def test_gen(server_db, rawtransactions_db):
 #     """Test cases generator.

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -284,15 +284,12 @@ def vector_to_args(vector, functions=[]):
     for tx_name in vector:
         for method in vector[tx_name]:
             for params in vector[tx_name][method]:
-                error = outputs = records = None
-                if 'out' in params:
-                    outputs = params['out']
-                if 'error' in params:
-                    error = params['error']
-                if 'records' in params:
-                    records = params['records']
+                error = params.get('error', None)
+                outputs = params.get('out', None)
+                records = params.get('records', None)
+                comment = params.get('comment', None)
                 if functions == [] or (tx_name + '.' + method) in functions:
-                    args.append((tx_name, method, params['in'], outputs, error, records))
+                    args.append((tx_name, method, params['in'], outputs, error, records, comment))
     return args
 
 def exec_tested_method(tx_name, method, tested_method, inputs, server_db):
@@ -306,7 +303,7 @@ def exec_tested_method(tx_name, method, tested_method, inputs, server_db):
     else:
         return tested_method(server_db, *inputs)
 
-def check_outputs(tx_name, method, inputs, outputs, error, records, server_db):
+def check_outputs(tx_name, method, inputs, outputs, error, records, comment, server_db):
     """Check actual and expected outputs of a particular function."""
 
     try:


### PR DESCRIPTION
makes it a little bit easier to debug failing tests without having to dig through the in/outs and finding which one matches.