### PR TITLE
fixing `backend.get_unspent_outputs` raising exception when a transaction contains an output with garbage data

### DIFF
--- a/counterpartylib/lib/backend/__init__.py
+++ b/counterpartylib/lib/backend/__init__.py
@@ -14,6 +14,7 @@ from bitcoin.core import CBlock
 from counterpartylib.lib import util
 from counterpartylib.lib import script
 from counterpartylib.lib import config
+from counterpartylib.lib import exceptions
 
 from counterpartylib.lib.backend import addrindex, btcd
 
@@ -123,7 +124,12 @@ def get_btc_supply(normalize=False):
 
 def is_scriptpubkey_spendable(scriptpubkey_hex, source, multisig_inputs=False):
     c_scriptpubkey = bitcoinlib.core.CScript(bitcoinlib.core.x(scriptpubkey_hex))
-    vout_address = script.scriptpubkey_to_address(c_scriptpubkey)
+
+    try:
+        vout_address = script.scriptpubkey_to_address(c_scriptpubkey)
+    except exceptions.DecodeError:
+        return False
+
     if not vout_address:
         return False
 

--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -620,9 +620,9 @@ def get_tx_info2(tx_hex, block_parser=None):
 
         # Ignore transactions with invalid script.
         try:
-          asm = script.get_asm(vout.scriptPubKey)
+            asm = script.get_asm(vout.scriptPubKey)
         except CScriptInvalidError as e:
-          raise DecodeError(e)
+            raise DecodeError(e)
 
         if asm[0] == 'OP_RETURN':
             new_destination, new_data = decode_opreturn(asm)

--- a/counterpartylib/lib/exceptions.py
+++ b/counterpartylib/lib/exceptions.py
@@ -23,6 +23,8 @@ class ValidateError(MessageError):
     pass
 class DecodeError(MessageError):
     pass
+class PushDataDecodeError(DecodeError):
+    pass
 class BTCOnlyError(MessageError):
     pass
 

--- a/counterpartylib/lib/script.py
+++ b/counterpartylib/lib/script.py
@@ -202,7 +202,7 @@ def get_asm(scriptpubkey):
                 # TODO: `data = element` (?)
                 asm.append(op)
     except bitcoinlib.core.script.CScriptTruncatedPushDataError:
-        raise exceptions.DecodeError('invalid pushdata due to truncation')
+        raise exceptions.PushDataDecodeError('invalid pushdata due to truncation')
     if not asm:
         raise exceptions.DecodeError('empty output')
     return asm
@@ -229,16 +229,20 @@ def get_checkmultisig(asm):
 
 def scriptpubkey_to_address(scriptpubkey):
     asm = get_asm(scriptpubkey)
+
     if asm[-1] == 'OP_CHECKSIG':
         try:
             checksig = get_checksig(asm)
-        except exceptions.DecodeError: # coinbase
+        except exceptions.DecodeError:  # coinbase
             return None
+
         return base58_check_encode(binascii.hexlify(checksig).decode('utf-8'), config.ADDRESSVERSION)
+
     elif asm[-1] == 'OP_CHECKMULTISIG':
         pubkeys, signatures_required = get_checkmultisig(asm)
         pubkeyhashes = [pubkey_to_pubkeyhash(pubkey) for pubkey in pubkeys]
         return construct_array(signatures_required, pubkeyhashes, len(pubkeyhashes))
+
     return None
 
 

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -8,6 +8,8 @@ The function supports three types of output checks:
 - PRAGMA changes - 'pragma'
 """
 
+import binascii
+import bitcoin as bitcoinlib
 from .params import ADDR, MULTISIGADDR, DEFAULT_PARAMS as DP
 
 from counterpartylib.lib import config
@@ -181,10 +183,18 @@ UNITTEST_VECTOR = {
             'in': (b'0100000001ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff0636150000000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac36150000000000001976a9147da51ea175f108a1c63588683dc4c43a7146c46788ac36150000000000001976a9147da51ea175f108a1c6358868173e34e8ca75a06788ac36150000000000001976a9147da51ea175f108a1c637729895c4c468ca75a06788ac36150000000000001976a9147fa51ea175f108a1c63588682ed4c468ca7fa06788ace24ff505000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000', DP['default_block']),
             'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 5430, 10000,  b'\x00\x00\x00(\x00\x00R\xbb3d\x00TESTXXXX\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00TESTXXXX\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00TESTXXXX\x00\x00\x00;\x10\x00\x00\x00\n\x9b\xb3Q\x92(6\xc8\x86\x81i\x87\xe1\x0b\x03\xb8_8v\x8b')
         }],
-        'get_tx_info2': [{
-            'in': (b'0100000001ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff0336150000000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac781e000000000000695121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753ae4286f505000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000',),
-            'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 5430, 10000, b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
-        }],
+        'get_tx_info2': [
+            # data in OP_CHECKMULTISIG script
+            {
+                'in': (b'0100000001ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff0336150000000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac781e000000000000695121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753ae4286f505000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000',),
+                'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 5430, 10000, b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
+            },
+            # data in OP_CHECKMULTISIG script, with extra op_return with garbage data
+            {
+                'in': (b'0100000001ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff0436150000000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac781e000000000000695121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753ae4286f505000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac0000000000000000116a5365746669766520736179732068692100000000',),
+                'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 5430, 10000, b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
+            }
+        ],
     },
     'cancel': {
         'compose': [{
@@ -1029,10 +1039,38 @@ UNITTEST_VECTOR = {
             'in': ('1_mnMrocns5kBjPZxRxXb5A1gx7gAoRZWPP6_mnMrocns5kBjPZxRxXb5A1gx7gAoRZWPP6_2',),
             'out': None
         }],
-        'scriptpubkey_to_address': [{
-            'in': (['mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH', 'mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH'],),
-            'out': None
-        }],
+        'scriptpubkey_to_address': [
+            # "OP_DUP OP_HASH160 4838d8b3588c4c7ba7c1d06f866e9b3739c63037 OP_EQUALVERIFY OP_CHECKSIG"
+            {
+                'in': (bitcoinlib.core.CScript(bitcoinlib.core.x('76a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac')),),
+                'out': "mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc"
+            },
+            # "OP_DUP OP_HASH160 8d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec OP_EQUALVERIFY OP_CHECKSIG"
+            {
+                'in': (bitcoinlib.core.CScript(bitcoinlib.core.x('76a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac')),),
+                'out': "mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns"
+            },
+            # "1 035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe35 02309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17 0319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b977 3 OP_CHECKMULTISIG"
+            {
+                'in': (bitcoinlib.core.CScript(bitcoinlib.core.x('5121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753ae')),),
+                'out': "1_mjH9amw2tJrsrw76PVvCkCQ18V4pZCVtm5_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_mvgph5nejRWUVvbzyq7TU9ENpJyV97ua37_3"
+            },
+            # when input is already an address, return None (don't raise)
+            {
+                'in': ('mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH',),
+                'out': None
+            },
+            # when input is a list of addresses, return None (don't raise)
+            {
+                'in': (['mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH', 'mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH'],),
+                'out': None
+            },
+            # when input is op_return with garbage data (a message with incorrect OP_PUSH), return None (don't raise)
+            {
+                'in': (bitcoinlib.core.CScript(bitcoinlib.core.x('6a53657466697665207361797320686921')),),
+                'error': (exceptions.PushDataDecodeError, 'invalid pushdata due to truncation')
+            }
+        ],
         'get_asm': [{
             'in': ([],),
             'error': (exceptions.DecodeError, 'empty output')


### PR DESCRIPTION
https://github.com/CounterpartyXCP/counterparty-lib/issues/810 occurs in `create_send` -> `backend.get_unspent_outputs` -> `backend.is_scriptpubkey_spendable` -> `script.scriptpubkey_to_address` path,  
blocks.get_tx_info is unaffected, so this isn't affecting consensus, only making certain transactions unspendable (and blocking any spending from a wallet).

`script.scriptpubkey_to_address` was raising an exception when it couldn't get the ASM from the `scriptPubKey`, this breaks `backend.get_unspent_outputs` and as a result breaks `create_send`.

I've only added a `try/except` for the `PushDataDecodeError` atm, but I think catching (the more generic) `DecodeError` would be even better,
I don't think this behavory of `script.scriptpubkey_to_address` raising an exception is desired, because we just want `None` returned for any scriptpubkeys that aren't spendable.