### PR TITLE
padding byte used should be `x00` not the `version`.

### DIFF
--- a/counterpartylib/lib/script.py
+++ b/counterpartylib/lib/script.py
@@ -106,7 +106,7 @@ def base58_check_decode(s, version):
             pad += 1
         else:
             break
-    k = version * pad + res
+    k = b'\x00' * pad + res
 
     addrbyte, data, chk0 = k[0:1], k[1:-4], k[-4:]
     if addrbyte != version:

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -1059,6 +1059,10 @@ UNITTEST_VECTOR = {
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', b'\x00'),
             'out': b"\x01\tfw`\x06\x95=UgC\x9e^9\xf8j\r';\xee"
         }, {
+            'comment': 'valid mainnet bitcoin address that contains a padding byte',
+            'in': ('13PGb7v3nmTDugLDStRJWXw6TzsNLUKJKC', b'\x00'),
+            'out': b'\x1a&jGxV\xea\xd2\x9e\xcb\xe6\xaeQ\xad:,\x8dG<\xf4'
+        }, {
             'comment': 'wrong version byte',
             'in': ('26UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', b'\x00'),
             'error': (script.VersionByteError, 'incorrect version byte')
@@ -1067,7 +1071,8 @@ UNITTEST_VECTOR = {
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvN', b'\x00'),
             'error': (script.Base58ChecksumError, 'Checksum mismatch: 0xd61967f7 ≠ 0xd61967f6')
         }, {
-            'in': (ADDR[0], b'\x6f'),                                                               # TODO: What is this?
+            'comment': 'valid testnet bitcoin address that we use in many tests',
+            'in': (ADDR[0], b'\x6f'),
             'out': b'H8\xd8\xb3X\x8cL{\xa7\xc1\xd0o\x86n\x9b79\xc607'
         }, {
             'comment': 'invalid mainnet bitcoin address: invalid character',


### PR DESCRIPTION
I think this was excidently replaced because it looks like the `b'\x00'` is exidentlal hardcoding, but it's not!

this mistake/bug had no effect up until I've started implementing P2SH.