### PR TITLE
force non-container based travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ notifications:
     secure: cl0G5fWZNnIK5VQ6BPZ4RtwVO2/nfvX/zjhljfF6cQ20OKyvyiJHq+e67fl2pkCKDlqlEqSWaQJ6G52YzUpDQmf+o7qpH6YnkFxSqYp5h4YF1hJw4sCHJ7bVSLrjogWxU8QaNvH7YpL4YkGe+WOau2FgoIZOcMt6hhKrvWclfuc=
 after_success:
 - coveralls
+
+sudo: required


### PR DESCRIPTION
unless there's `sudo` in the `.travis.yml` repos after  2015-01-01 default to container based builds (which disables `sudo` for faster builds).
installing serpent requires `sudo` so we need it.

the main repo never had issues with it because it's older than 2015-01-01, but when I want to run travis for my own repo, it fails.

more info: https://docs.travis-ci.com/user/workers/container-based-infrastructure/ and https://docs.travis-ci.com/user/workers/standard-infrastructure/

