### PR TITLE
use the data from the block instead of hitting RPC for raw TXs.

### DIFF
--- a/counterpartylib/lib/backend/__init__.py
+++ b/counterpartylib/lib/backend/__init__.py
@@ -85,6 +85,19 @@ def is_valid(address):
 def get_txhash_list(block):
     return [bitcoinlib.core.b2lx(ctx.GetHash()) for ctx in block.vtx]
 
+def get_tx_list(block):
+    raw_transactions = {}
+    tx_hash_list = []
+
+    for ctx in block.vtx:
+        tx_hash = bitcoinlib.core.b2lx(ctx.GetHash())
+        raw = ctx.serialize()
+
+        tx_hash_list.append(tx_hash)
+        raw_transactions[tx_hash] = bitcoinlib.core.b2x(raw)
+
+    return (tx_hash_list, raw_transactions)
+
 def input_value_weight(amount):
     # Prefer outputs less than dust size, then bigger is better.
     if amount * config.UNIT <= config.DEFAULT_REGULAR_DUST_SIZE:

--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -1120,8 +1120,8 @@ def follow(db):
             block = backend.getblock(block_hash)
             previous_block_hash = bitcoinlib.core.b2lx(block.hashPrevBlock)
             block_time = block.nTime
-            txhash_list = backend.get_txhash_list(block)
-            raw_transactions = backend.getrawtransaction_batch(txhash_list)
+            txhash_list, raw_transactions = backend.get_tx_list(block)
+
             with db:
                 util.CURRENT_BLOCK_INDEX = block_index
 


### PR DESCRIPTION
Sean brought up some questions about the raw TX cache and it made me think about why we're even querying the RPC for the raw TXs when parsing blocks.

Easy fix for a pretty big performance gain.

Improvement from 2~3s to < 0.1s for me