### PR TITLE
add --verbosediff option for unit tests

### DIFF
--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -58,6 +58,7 @@ def pytest_addoption(parser):
     parser.addoption("--gentxhex", action='store_true', default=False, help="generate and print unsigned hex for *.compose() tests")
     parser.addoption("--savescenarios", action='store_true', default=False, help="generate sql dump and log in .new files")
     parser.addoption("--skiptestbook", default='no', help="skip test book(s) (use with one of the following values: `all`, `testnet` or `mainnet`)")
+    parser.addoption("--verbosediff", action='store_true', default=False, help="print verbose diff for vectors that fail")
 
 @pytest.fixture(scope="module")
 def rawtransactions_db(request):

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -4,6 +4,8 @@ This module contains a variety of utility functions used in the test suite.
 
 import os, sys, hashlib, binascii, time, decimal, logging, locale, re, io
 import difflib, json, inspect, tempfile, shutil
+import pprint
+
 import apsw, pytest, requests
 from requests.auth import HTTPBasicAuth
 
@@ -334,7 +336,11 @@ def check_outputs(tx_name, method, inputs, outputs, error, records, comment, ser
         try:
             assert outputs == test_outputs
         except AssertionError:
-            raise Exception("outputs don't match test_outputs: outputs=%s  ---  test_outputs=%s" % (outputs, test_outputs))
+            if pytest.config.option.verbosediff:
+                msg = "outputs don't match test_outputs:\noutputs=\n" + pprint.pformat(outputs) + "\ntest_outputs=\n" + pprint.pformat(test_outputs)
+            else:
+                msg = "outputs don't match test_outputs: outputs=%s test_outputs=%s" % (outputs, test_outputs)
+            raise Exception(msg)
     if error is not None:
         assert str(exception.value) == error[1]
     if records is not None:

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -337,9 +337,9 @@ def check_outputs(tx_name, method, inputs, outputs, error, records, comment, ser
             assert outputs == test_outputs
         except AssertionError:
             if pytest.config.option.verbosediff:
-                msg = "outputs don't match test_outputs:\noutputs=\n" + pprint.pformat(outputs) + "\ntest_outputs=\n" + pprint.pformat(test_outputs)
+                msg = "expected outputs don't match test_outputs:\noutputs=\n" + pprint.pformat(outputs) + "\ntest_outputs=\n" + pprint.pformat(test_outputs)
             else:
-                msg = "outputs don't match test_outputs: outputs=%s test_outputs=%s" % (outputs, test_outputs)
+                msg = "expected outputs don't match test_outputs: outputs=%s test_outputs=%s" % (outputs, test_outputs)
             raise Exception(msg)
     if error is not None:
         assert str(exception.value) == error[1]


### PR DESCRIPTION
imo should should be the default, but it's a --arg in case ppl don't like it ...

```
Exception: outputs don't match test_outputs: outputs=(0, [{'dividend_quantity': 0, 'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'address_quantity': 100000000}, {'dividend_quantity': 0, 'address': '1_mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_2', 'address_quantity': 1000000000}], ['insufficient funds (XCP)'], 0) test_outputs=(0, [{'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 91950000000}, {'dividend_quantity': 0, 'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'address_quantity': 99999990}, {'dividend_quantity': 0, 'address': '1_mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_2', 'address_quantity': 300000000}, {'dividend_quantity': 0, 'address': 'mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH', 'address_quantity': 0}, {'dividend_quantity': 0, 'address': 'mqPCfvqTfYctXMUfmniXeG2nyaN8w6tPmj', 'address_quantity': 92945878046}, {'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 100000000}, {'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 100000000}, {'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 100000000}, {'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 0}, {'dividend_quantity': 0, 'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', 'address_quantity': 100000000}, {'dividend_quantity': 0, 'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', 'address_quantity': 10}], ['non‐positive quantity per unit', 'zero dividend', 'insufficient funds (XCP)'], 0)
```

VS

```
E               Exception: outputs don't match test_outputs:
E               outputs=
E               (0,
E                [{'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns',
E                  'address_quantity': 100000000,
E                  'dividend_quantity': 0},
E                 {'address': '1_mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_2',
E                  'address_quantity': 1000000000,
E                  'dividend_quantity': 0}],
E                ['insufficient funds (XCP)'],
E                0)
E               test_outputs=
E               (0,
E                [{'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 91950000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns',
E                  'address_quantity': 99999990,
E                  'dividend_quantity': 0},
E                 {'address': '1_mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc_mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns_2',
E                  'address_quantity': 300000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH',
E                  'address_quantity': 0,
E                  'dividend_quantity': 0},
E                 {'address': 'mqPCfvqTfYctXMUfmniXeG2nyaN8w6tPmj',
E                  'address_quantity': 92945878046,
E                  'dividend_quantity': 0},
E                 {'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 100000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 100000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 100000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 0,
E                  'dividend_quantity': 0},
E                 {'address': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
E                  'address_quantity': 100000000,
E                  'dividend_quantity': 0},
E                 {'address': 'mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns',
E                  'address_quantity': 10,
E                  'dividend_quantity': 0}],
E                ['non‐positive quantity per unit',
E                 'zero dividend',
E                 'insufficient funds (XCP)'],
E                0)
```