### PR TITLE
only getrawtransaction for the TXs we want to parse

### DIFF
--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -1210,7 +1210,7 @@ def follow(db):
             #  - or was there a block found while batch feting the raw txs
             #  - or was there a double spend for w/e reason accepted into the mempool (replace-by-fee?)
             try:
-                raw_transactions = backend.getrawtransaction_batch(raw_mempool)
+                raw_transactions = backend.getrawtransaction_batch(parse_txs)
             except backend.addrindex.BackendRPCError as e:
                 logger.warning('Failed to fetch raw for mempool TXs, restarting loop; %s', (e, ))
                 continue  # restart the follow loop


### PR DESCRIPTION
I think something went wrong with the refactoring I did a while back, this was the whole point, fetching less TXs ...

we dont use that `raw_transactions` anywhere except in the `for tx_hash in parse_txs:` loop and `refresh_unconfirmed_transactions_cache` is responsible for fetching it's own list of raw transactions.