### PR TITLE
Add a way to have vectors for code paths before protocol changes.

### DIFF
--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -27,6 +27,16 @@ from counterpartylib.lib import config, util, backend, transaction, database, ap
 import bitcoin as bitcoinlib
 import bitcoin.rpc as bitcoinlib_rpc
 
+# we swap out util.enabled with a custom one which has the option to mock the protocol changes
+MOCK_PROTOCOL_CHANGES = {}
+_enabled = util.enabled
+def enabled(change_name, block_index=None):
+    if change_name in MOCK_PROTOCOL_CHANGES:
+        return MOCK_PROTOCOL_CHANGES[change_name]
+
+    return _enabled(change_name, block_index)
+util.enabled = enabled
+
 def pytest_collection_modifyitems(session, config, items):
     """Run contracts_test.py last."""
     items[:] = list(reversed(items))
@@ -35,7 +45,7 @@ def pytest_generate_tests(metafunc):
     """Generate all py.test cases. Checks for different types of tests and creates proper context."""
     if metafunc.function.__name__ == 'test_vector':
         args = util_test.vector_to_args(UNITTEST_VECTOR, pytest.config.option.function)
-        metafunc.parametrize('tx_name, method, inputs, outputs, error, records, comment', args)
+        metafunc.parametrize('tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes', args)
     elif metafunc.function.__name__ == 'test_scenario':
         args = []
         for scenario_name in INTEGRATION_SCENARIOS:

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -2620,9 +2620,13 @@ UNITTEST_VECTOR = {
         'enabled': [{
             'in': ('numeric_asset_names',),
             'out': True
-        },  {
+        }, {
             'in': ('foobar',),
             'error': (KeyError, "'foobar'")
+        }, {
+            'mock_protocol_changes': {'numeric_asset_names': False},
+            'in': ('numeric_asset_names',),
+            'out': False
         }],
         'date_passed': [{
             'comment': 'date in the past, mock function overrides this one and always returns `False` in the test suite',

--- a/counterpartylib/test/unit_test.py
+++ b/counterpartylib/test/unit_test.py
@@ -13,12 +13,12 @@ FIXTURE_DB = tempfile.gettempdir() + '/fixtures.unittest_fixture.db'
 
 
 @pytest.mark.usefixtures("api_server")
-def test_vector(tx_name, method, inputs, outputs, error, records, comment, server_db):
+def test_vector(tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, server_db):
     """Test the outputs of unit test vector. If testing parse, execute the transaction data on test db."""
     if method == 'parse':
         util_test.insert_transaction(inputs[0], server_db)
         inputs += (inputs[0]['data'][4:],) # message arg
-    util_test.check_outputs(tx_name, method, inputs, outputs, error, records, comment, server_db)
+    util_test.check_outputs(tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, server_db)
 
 # def test_gen(server_db, rawtransactions_db):
 #     """Test cases generator.

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -321,8 +321,9 @@ def vector_to_args(vector, functions=[]):
                 outputs = params.get('out', None)
                 records = params.get('records', None)
                 comment = params.get('comment', None)
+                mock_protocol_changes = params.get('mock_protocol_changes', None)
                 if functions == [] or (tx_name + '.' + method) in functions:
-                    args.append((tx_name, method, params['in'], outputs, error, records, comment))
+                    args.append((tx_name, method, params['in'], outputs, error, records, comment, mock_protocol_changes))
     return args
 
 def exec_tested_method(tx_name, method, tested_method, inputs, server_db):
@@ -336,7 +337,7 @@ def exec_tested_method(tx_name, method, tested_method, inputs, server_db):
     else:
         return tested_method(server_db, *inputs)
 
-def check_outputs(tx_name, method, inputs, outputs, error, records, comment, server_db):
+def check_outputs(tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, server_db):
     """Check actual and expected outputs of a particular function."""
 
     try:
@@ -344,6 +345,12 @@ def check_outputs(tx_name, method, inputs, outputs, error, records, comment, ser
     except KeyError:    # TODO: hack
         tested_module = sys.modules['counterpartylib.lib.messages.{}'.format(tx_name)]
     tested_method = getattr(tested_module, method)
+
+    # import here to avoid circular imports
+    from counterpartylib.test.conftest import MOCK_PROTOCOL_CHANGES
+    MOCK_PROTOCOL_CHANGES.clear()
+    if mock_protocol_changes:
+        MOCK_PROTOCOL_CHANGES.update(mock_protocol_changes)
 
     test_outputs = None
     if error is not None:


### PR DESCRIPTION
It's not the first time that I add a protocol change and regret that I can no longer test the old codepath, so here it is!

just add `'mock_protocol_changes': {"protocol_change": False}` to disable a particular protocol change (see: https://github.com/CounterpartyXCP/counterparty-lib/pull/855/commits/6ea2e8ce02c5ef2951042705378cb85858c29cb2#diff-fa3ae8bc7e155d00792f770690403cbbR402 for it in action).

we need this because when you reparse from 0 the older protocol changes shouldn't change with future code changes.