### PR TITLE
seperate the base58_check_decode into smaller functions that can be used seperately.

### DIFF
--- a/counterpartylib/lib/script.py
+++ b/counterpartylib/lib/script.py
@@ -29,9 +29,10 @@ class Base58Error (AddressError):
 class Base58ChecksumError (Base58Error):
     pass
 
+
 def validate(address):
     """Make sure the address is valid.
-    
+
     May throw `AddressError`.
     """
     # Get array of pubkeyhashes to check.
@@ -43,6 +44,7 @@ def validate(address):
     # Check validity by attempting to decode.
     for pubkeyhash in pubkeyhashes:
         base58_check_decode(pubkeyhash, config.ADDRESSVERSION)
+
 
 def base58_encode(binary):
     """Encode the address in base58."""
@@ -57,6 +59,7 @@ def base58_encode(binary):
     res = ''.join(res[::-1])
 
     return res
+
 
 def base58_check_encode(original, version):
     """Check if base58 encoding is valid."""
@@ -82,8 +85,8 @@ def base58_check_encode(original, version):
 
     return address
 
-def base58_check_decode(s, version):
-    """Decode from base58."""
+
+def base58_decode(s):
     # Convert the string to an integer
     n = 0
     for c in s:
@@ -108,12 +111,31 @@ def base58_check_decode(s, version):
             break
     k = b'\x00' * pad + res
 
+    return k
+
+
+def base58_check_decode_parts(s):
+    """Decode from base58 and return parts."""
+
+    k = base58_decode(s)
+
     addrbyte, data, chk0 = k[0:1], k[1:-4], k[-4:]
+
+    return addrbyte, data, chk0
+
+
+def base58_check_decode(s, version):
+    """Decode from base58 and return data part."""
+
+    addrbyte, data, chk0 = base58_check_decode_parts(s)
+
     if addrbyte != version:
         raise VersionByteError('incorrect version byte')
+
     chk1 = util.dhash(addrbyte + data)[:4]
     if chk0 != chk1:
         raise Base58ChecksumError('Checksum mismatch: 0x{} ≠ 0x{}'.format(util.hexlify(chk0), util.hexlify(chk1)))
+
     return data
 
 

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -2179,6 +2179,58 @@ UNITTEST_VECTOR = {
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjv0', b'\x00'),
             'error': (script.Base58Error, "Not a valid Base58 character: ‘0’")
         }],
+        # base58_decode is the raw decoding, we use the test cases from base58_check_decode
+        'base58_decode': [{
+            'comment': 'valid mainnet bitcoin address',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', ),
+            'out': b"\x00\x01\tfw`\x06\x95=UgC\x9e^9\xf8j\r';\xee\xd6\x19g\xf6"
+        }, {
+            'comment': 'valid mainnet bitcoin address that contains a padding byte',
+            'in': ('13PGb7v3nmTDugLDStRJWXw6TzsNLUKJKC', ),
+            'out': b'\x00\x1a&jGxV\xea\xd2\x9e\xcb\xe6\xaeQ\xad:,\x8dG<\xf4\x07eG#'
+        }, {
+            'comment': 'wrong version byte',
+            'in': ('26UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', ),
+            'out': b'\x0c\x01\x86\xaa\xbd\xa1\xd2\xdaJ\xf2\xd4\xbb\xe5=N\xe2\x08\xa6\x8eo\xd6\x19g\xf6'
+        }, {
+            'comment': 'invalid mainnet bitcoin address: bad checksum',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvN', ),
+            'out': b"\x00\x01\tfw`\x06\x95=UgC\x9e^9\xf8j\r';\xee\xd6\x19g\xf7"
+        }, {
+            'comment': 'valid testnet bitcoin address that we use in many tests',
+            'in': (ADDR[0], ),
+            'out': b'oH8\xd8\xb3X\x8cL{\xa7\xc1\xd0o\x86n\x9b79\xc607\x98!\xc4U'
+        }, {
+            'comment': 'invalid mainnet bitcoin address: invalid character',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjv0', ),
+            'error': (script.Base58Error, "Not a valid Base58 character: ‘0’")
+        }],
+        # base58_check_decode_parts is the raw decoding and splitting, we use the test cases from base58_check_decode
+        'base58_check_decode_parts': [{
+            'comment': 'valid mainnet bitcoin address',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', ),
+            'out': (b'\x00', b"\x01\tfw`\x06\x95=UgC\x9e^9\xf8j\r';\xee", b'\xd6\x19g\xf6')
+        }, {
+            'comment': 'valid mainnet bitcoin address that contains a padding byte',
+            'in': ('13PGb7v3nmTDugLDStRJWXw6TzsNLUKJKC', ),
+            'out': (b'\x00', b'\x1a&jGxV\xea\xd2\x9e\xcb\xe6\xaeQ\xad:,\x8dG<\xf4', b'\x07eG#')
+        }, {
+            'comment': 'wrong version byte',
+            'in': ('26UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', ),
+            'out': (b'\x0c', b'\x01\x86\xaa\xbd\xa1\xd2\xdaJ\xf2\xd4\xbb\xe5=N\xe2\x08\xa6\x8eo', b'\xd6\x19g\xf6')
+        }, {
+            'comment': 'invalid mainnet bitcoin address: bad checksum',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvN', ),
+            'out': (b'\x00', b"\x01\tfw`\x06\x95=UgC\x9e^9\xf8j\r';\xee", b'\xd6\x19g\xf7')
+        }, {
+            'comment': 'valid testnet bitcoin address that we use in many tests',
+            'in': (ADDR[0], ),
+            'out':  (b'o', b'H8\xd8\xb3X\x8cL{\xa7\xc1\xd0o\x86n\x9b79\xc607', b'\x98!\xc4U')
+        }, {
+            'comment': 'invalid mainnet bitcoin address: invalid character',
+            'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjv0', ),
+            'error': (script.Base58Error, "Not a valid Base58 character: ‘0’")
+        }],
         'is_multisig': [{
             'comment': 'mono‐sig',
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM',),


### PR DESCRIPTION
nothing major, just making it easy to base58 decode without the version and checksum checks.