### PR TITLE
better use of pytest fixtures

### DIFF
--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -37,6 +37,8 @@ json_print = lambda x: print(json.dumps(x, sort_keys=True, indent=4))
 
 BLOCK_LEDGER = []
 
+CURRENT_BLOCK_INDEX = None
+
 CURR_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(CURR_DIR + '/../protocol_changes.json') as f:
     PROTOCOL_CHANGES = json.load(f)
@@ -317,6 +319,7 @@ def credit (db, address, asset, quantity, action=None, event=None):
         'event': event
     }
     sql='insert into credits values(:block_index, :address, :asset, :quantity, :action, :event)'
+
     credit_cursor.execute(sql, bindings)
     credit_cursor.close()
 

--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -13,14 +13,16 @@ sys.path.insert(0, base_dir)
 
 import json, binascii, apsw
 from datetime import datetime
+import time
 
-import pytest, util_test
+import pytest
+from counterpartylib.test import util_test
 
-from fixtures.vectors import UNITTEST_VECTOR
-from fixtures.params import DEFAULT_PARAMS
-from fixtures.scenarios import INTEGRATION_SCENARIOS
+from counterpartylib.test.fixtures.vectors import UNITTEST_VECTOR
+from counterpartylib.test.fixtures.params import DEFAULT_PARAMS
+from counterpartylib.test.fixtures.scenarios import INTEGRATION_SCENARIOS
 
-from counterpartylib.lib import config, util, backend, transaction
+from counterpartylib.lib import config, util, backend, transaction, database, api
 
 import bitcoin as bitcoinlib
 import bitcoin.rpc as bitcoinlib_rpc
@@ -60,6 +62,7 @@ def pytest_addoption(parser):
     parser.addoption("--skiptestbook", default='no', help="skip test book(s) (use with one of the following values: `all`, `testnet` or `mainnet`)")
     parser.addoption("--verbosediff", action='store_true', default=False, help="print verbose diff for vectors that fail")
 
+
 @pytest.fixture(scope="module")
 def rawtransactions_db(request):
     """Return a database object."""
@@ -68,7 +71,48 @@ def rawtransactions_db(request):
         util_test.initialise_rawtransactions_db(db)
     return db
 
-@pytest.fixture(autouse=True)
+
+@pytest.fixture(scope='function')
+def server_db(request, cp_server):
+    """Enable database access for unit test vectors."""
+    db = database.get_connection(read_only=False, integrity_check=False)
+    cursor = db.cursor()
+    cursor.execute('''BEGIN''')
+    util_test.reset_current_block_index(db)
+
+    request.addfinalizer(lambda: cursor.execute('''ROLLBACK'''))
+    request.addfinalizer(lambda: util_test.reset_current_block_index(db))
+
+    return db
+
+
+@pytest.fixture(scope='module')
+def api_server(request, cp_server):
+    # start RPC server and wait for server to be ready
+    api_server = api.APIServer()
+    api_server.daemon = True
+    api_server.start()
+    for attempt in range(5000):  # wait until server is ready.
+        if api_server.is_ready:
+            break
+        elif attempt == 4999:
+            raise Exception("Timeout: RPC server not ready after 5s")
+        else:
+            time.sleep(0.001)  # attempt to query the current block_index if possible (scenarios start with empty DB so it's not always possible)
+
+
+@pytest.fixture(scope='module')
+def cp_server(request):
+    print('cp_server')
+    dbfile = getattr(request.module, 'FIXTURE_DB')
+    sqlfile = getattr(request.module, 'FIXTURE_SQL_FILE')
+
+    util_test.init_database(sqlfile, dbfile)
+
+    request.addfinalizer(lambda: util_test.remove_database_files(dbfile))
+
+
+@pytest.fixture(scope='function', autouse=True)
 def init_mock_functions(monkeypatch, rawtransactions_db):
     """Test suit mock functions.
 
@@ -92,7 +136,7 @@ def init_mock_functions(monkeypatch, rawtransactions_db):
     def date_passed(date):
         return False
 
-    def init_api_access_log():
+    def init_api_access_log(app):
         pass
 
     def pubkeyhash_to_pubkey(address, provided_pubkeys=None):
@@ -109,8 +153,6 @@ def init_mock_functions(monkeypatch, rawtransactions_db):
 
     def get_cached_raw_transaction(tx_hash, verbose=False):
         return util_test.getrawtransaction(rawtransactions_db, bitcoinlib.core.lx(tx_hash))
-
-    util.CURRENT_BLOCK_INDEX = DEFAULT_PARAMS['default_block_index'] - 1
 
     monkeypatch.setattr('counterpartylib.lib.backend.get_unspent_txouts', get_unspent_txouts)
     monkeypatch.setattr('counterpartylib.lib.log.isodt', isodt)

--- a/counterpartylib/test/unit_test.py
+++ b/counterpartylib/test/unit_test.py
@@ -7,39 +7,12 @@ from fixtures.vectors import UNITTEST_VECTOR
 from fixtures.params import DEFAULT_PARAMS as DP
 
 from counterpartylib.lib import (config, util, api, database)
-import server
 
-def setup_module():
-    """Initialise the database with default data and wait for server to be ready."""
-    server.initialise(database_file=tempfile.gettempdir() + '/fixtures.unittest.db', testnet=True, **util_test.COUNTERPARTYD_OPTIONS)
-    db = util_test.restore_database(config.DATABASE, CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql')
-    util.FIRST_MULTISIG_BLOCK_TESTNET = 1
-    # start RPC server
-    api_server = api.APIServer()
-    api_server.daemon = True
-    api_server.start()
-    for attempt in range(5000): # wait until server is ready.
-        if api_server.is_ready:
-            break
-        elif attempt == 4999:
-            raise Exception("Timeout: RPC server not ready after 5s")
-        else:
-            time.sleep(0.001)
+FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql'
+FIXTURE_DB = tempfile.gettempdir() + '/fixtures.unittest_fixture.db'
 
-def teardown_module(function):
-    """Delete the temporary database."""
-    util_test.remove_database_files(config.DATABASE)
 
-@pytest.fixture
-def server_db(request):
-    """Enable database access for unit test vectors."""
-    db = database.get_connection(read_only=False)
-    database.update_version(db)
-    cursor = db.cursor()
-    cursor.execute('''BEGIN''')
-    request.addfinalizer(lambda: cursor.execute('''ROLLBACK'''))
-    return db
-
+@pytest.mark.usefixtures("api_server")
 def test_vector(tx_name, method, inputs, outputs, error, records, comment, server_db):
     """Test the outputs of unit test vector. If testing parse, execute the transaction data on test db."""
     if method == 'parse':

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -290,8 +290,8 @@ def check_record(record, server_db):
 def vector_to_args(vector, functions=[]):
     """Translate from UNITTEST_VECTOR style to function arguments."""
     args = []
-    for tx_name in vector:
-        for method in vector[tx_name]:
+    for tx_name in sorted(vector.keys()):
+        for method in sorted(vector[tx_name].keys()):
             for params in vector[tx_name][method]:
                 error = params.get('error', None)
                 outputs = params.get('out', None)


### PR DESCRIPTION
this prevents some odd shit happening in a few other PRs and it makes it a lot easier to add more tests.

see https://github.com/CounterpartyXCP/counterparty-lib/pull/859 for how it makes it easy to add `parse_block_test.py`

depends on #860