### PR TITLE
change TravisCI and CircleCI to make it easier to read the error reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,3 @@ after_success:
 - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 - if [ "$BRANCH" == "master" ]; then docker push counterparty/counterparty-server:latest; fi 
 - if [ "$BRANCH" == "develop" ]; then docker push counterparty/counterparty-server:develop; fi 
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ notifications:
 after_success:
 - coveralls
 # if it's master or develop, then push the appropirately tagged docker image (otherwise don't push anything)
-- docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-- if [ "$BRANCH" == "master" ]; then docker push counterparty/counterparty-server:latest; fi 
-- if [ "$BRANCH" == "develop" ]; then docker push counterparty/counterparty-server:develop; fi 
+- |
+  if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    if [ "$BRANCH" == "master" ]; then docker push counterparty/counterparty-server:latest; fi
+    if [ "$BRANCH" == "develop" ]; then docker push counterparty/counterparty-server:develop; fi
+  fi

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ $ python3
 ```
 
 
+# Travis/Circle CI
+ - TravisCI is setup to run all tests with 1 command and generate a coverage report and let `python-coveralls` parse and upload it.
+   It does runs with `--skiptestbook=all` so it will not do the reparsing of the bootstrap files.
+ - CircleCI is setup to split the tests as much as possible to make it easier to read the error reports.
+   It also runs the `integration_test.test_book` tests, which reparse the bootstrap files.
+
+
 # Further Reading
 
 * [Official Project Documentation](http://counterparty.io/docs/)

--- a/circle.yml
+++ b/circle.yml
@@ -5,11 +5,18 @@ dependencies:
         - python setup.py install --with-serpent
 test:
     override:
-        - cd counterpartylib; py.test --verbose --capture=no --cov-config=../.coveragerc --cov-report=term-missing --cov=./
+        - py.test --verbose --capture=no counterpartylib/test/unit_test.py
+        - py.test --verbose --capture=no counterpartylib/test/parse_block_test.py
+        - py.test --verbose --capture=no --skiptestbook=all counterpartylib/test/integration_test.py
+        - py.test --verbose --capture=no --skiptestbook=mainnet -k test_book counterpartylib/test/reparse_test.py
+        - py.test --verbose --capture=no --skiptestbook=testnet -k test_book counterpartylib/test/reparse_test.py
+        - py.test counterpartylib/test/contracts_test.py
 machine:
     pre:
-        - mkdir -p ~/.local/share/counterparty
-        - cd ~/.local/share/counterparty; wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db.latest.tar.gz; tar xvzf counterparty-db.latest.tar.gz;
-        - cd ~/.local/share/counterparty; wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db-testnet.latest.tar.gz; tar xvzf counterparty-db-testnet.latest.tar.gz;
+        - mkdir -p ~/.local/share/counterparty;
+        - wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db-testnet.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz;
+        - tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz;
+        - wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db.latest.tar.gz;
+        - tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db.latest.tar.gz;
     python:
         version: 3.4.1

--- a/counterpartylib/test/integration_test.py
+++ b/counterpartylib/test/integration_test.py
@@ -2,10 +2,11 @@
 import tempfile
 import pytest
 
-import util_test
-from util_test import CURR_DIR
-import server
+from counterpartylib.test import util_test
+from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib import server
 from counterpartylib.lib import (config, check, database)
+
 
 def test_scenario(scenario_name, base_scenario_name, transactions, rawtransactions_db):
     """Run the integration tests.
@@ -28,29 +29,3 @@ def test_scenario(scenario_name, base_scenario_name, transactions, rawtransactio
         clean_new_dump = util_test.clean_scenario_dump(scenario_name, new_dump)
         clean_base_dump = util_test.clean_scenario_dump(base_scenario_name, base_dump)
         assert util_test.compare_strings(clean_base_dump, clean_new_dump) == 0
-
-def test_book(testnet):
-    """Reparse all the transactions in the database to see check blockhain's integrity."""
-    util_test.reparse(testnet=testnet)
-
-def test_check_database_version():
-    server.initialise(database_file=tempfile.gettempdir() + '/fixtures.unittest.db', testnet=True, **util_test.COUNTERPARTYD_OPTIONS)
-    util_test.restore_database(config.DATABASE, CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql')
-    db = database.get_connection(read_only=False)
-    database.update_version(db)
-
-    version_major, version_minor = database.version(db)
-    assert config.VERSION_MAJOR == version_major
-    assert config.VERSION_MINOR == version_minor
-
-    check.database_version(db)
-
-    config.VERSION_MINOR += 1
-    with pytest.raises(check.DatabaseVersionError) as exception:
-        check.database_version(db)
-    assert exception.value.reparse_block_index == None
-
-    config.VERSION_MAJOR += 1
-    with pytest.raises(check.DatabaseVersionError) as exception:
-        check.database_version(db)
-    assert exception.value.reparse_block_index == config.BLOCK_FIRST

--- a/counterpartylib/test/parse_block_test.py
+++ b/counterpartylib/test/parse_block_test.py
@@ -2,12 +2,10 @@
 import pprint
 import sys, os, time, tempfile
 import pytest
-from counterpartylib.test import util_test
 from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP
 from counterpartylib.test.util_test import CURR_DIR
 
 from counterpartylib.lib import (config, util, database, blocks)
-from counterpartylib import server
 
 
 FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/parseblock_unittest_fixture.sql'

--- a/counterpartylib/test/reparse_test.py
+++ b/counterpartylib/test/reparse_test.py
@@ -1,0 +1,36 @@
+#! /usr/bin/python3
+import tempfile
+import pytest
+
+from counterpartylib.test import util_test
+from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib import server
+from counterpartylib.lib import (config, check, database)
+
+
+def test_book(testnet):
+    """Reparse all the transactions in the database to see check blockhain's integrity."""
+    util_test.reparse(testnet=testnet)
+
+
+def test_check_database_version():
+    server.initialise(database_file=tempfile.gettempdir() + '/fixtures.unittest.db', testnet=True, **util_test.COUNTERPARTYD_OPTIONS)
+    util_test.restore_database(config.DATABASE, CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql')
+    db = database.get_connection(read_only=False)
+    database.update_version(db)
+
+    version_major, version_minor = database.version(db)
+    assert config.VERSION_MAJOR == version_major
+    assert config.VERSION_MINOR == version_minor
+
+    check.database_version(db)
+
+    config.VERSION_MINOR += 1
+    with pytest.raises(check.DatabaseVersionError) as exception:
+        check.database_version(db)
+    assert exception.value.reparse_block_index == None
+
+    config.VERSION_MAJOR += 1
+    with pytest.raises(check.DatabaseVersionError) as exception:
+        check.database_version(db)
+    assert exception.value.reparse_block_index == config.BLOCK_FIRST

--- a/counterpartylib/test/unit_test.py
+++ b/counterpartylib/test/unit_test.py
@@ -2,10 +2,10 @@
 import sys, os, time, tempfile
 import pytest
 import logging
-import util_test
-from util_test import CURR_DIR
-from fixtures.vectors import UNITTEST_VECTOR
-from fixtures.params import DEFAULT_PARAMS as DP
+from counterpartylib.test import util_test
+from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib.test.fixtures.vectors import UNITTEST_VECTOR
+from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP
 
 from counterpartylib.lib import (config, util, api, database, log)
 import server


### PR DESCRIPTION
Depends on: https://github.com/CounterpartyXCP/counterparty-lib/pull/886

Many times when CircleCI crashes (often on the test that does the reparsing) the log is impossible to read because they limit the log to 4mb.

I've separated each test for CircleCI so that they'll show up in separate sections and reset the limit on the size of the log.

while keeping TravisCI running as a single command so that the coverage report that coveralls uses is still the most complete.