### PR TITLE
Avoid credentials in logs

### DIFF
--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -18,16 +18,6 @@ raw_transactions_cache = util.DictCache(size=config.BACKEND_RAW_TRANSACTIONS_CAC
 unconfirmed_transactions_cache = None
 reverse_unconfirmed_transactions_cache = None
 
-URL_USERNAMEPASS_REGEX = re.compile('.+://(.+)@')
-
-
-def clean_url_for_log(url):
-    m = URL_USERNAMEPASS_REGEX.match(url)
-    if m and m.group(1):
-        url = url.replace(m.group(1), 'XXXXXXXX')
-
-    return url
-
 
 class BackendRPCError(Exception):
     pass
@@ -46,7 +36,7 @@ def rpc_call(payload):
                 logger.debug('Successfully connected.')
             break
         except (Timeout, ReadTimeout, ConnectionError):
-            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(clean_url_for_log(url), i+1, TRIES))
+            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(util.clean_url_for_log(url), i+1, TRIES))
             time.sleep(5)
 
     if response == None:
@@ -54,7 +44,7 @@ def rpc_call(payload):
             network = 'testnet'
         else:
             network = 'mainnet'
-        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(clean_url_for_log(url), network))
+        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(util.clean_url_for_log(url), network))
     elif response.status_code not in (200, 500):
         raise BackendRPCError(str(response.status_code) + ' ' + response.reason)
 

--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -14,12 +14,24 @@ import hashlib
 
 from counterpartylib.lib import config, script, util
 
-raw_transactions_cache = util.DictCache(size=config.BACKEND_RAW_TRANSACTIONS_CACHE_SIZE) #used in getrawtransaction_batch()
+raw_transactions_cache = util.DictCache(size=config.BACKEND_RAW_TRANSACTIONS_CACHE_SIZE)  # used in getrawtransaction_batch()
 unconfirmed_transactions_cache = None
 reverse_unconfirmed_transactions_cache = None
 
+URL_USERNAMEPASS_REGEX = re.compile('.+://(.+)@')
+
+
+def clean_url_for_log(url):
+    m = URL_USERNAMEPASS_REGEX.match(url)
+    if m and m.group(1):
+        url = url.replace(m.group(1), 'XXXXXXXX')
+
+    return url
+
+
 class BackendRPCError(Exception):
     pass
+
 
 def rpc_call(payload):
     url = config.BACKEND_URL
@@ -34,7 +46,7 @@ def rpc_call(payload):
                 logger.debug('Successfully connected.')
             break
         except (Timeout, ReadTimeout, ConnectionError):
-            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(url, i+1, TRIES))
+            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(clean_url_for_log(url), i+1, TRIES))
             time.sleep(5)
 
     if response == None:
@@ -42,7 +54,7 @@ def rpc_call(payload):
             network = 'testnet'
         else:
             network = 'mainnet'
-        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(url, network))
+        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(clean_url_for_log(url), network))
     elif response.status_code not in (200, 500):
         raise BackendRPCError(str(response.status_code) + ' ' + response.reason)
 

--- a/counterpartylib/lib/backend/btcd.py
+++ b/counterpartylib/lib/backend/btcd.py
@@ -4,7 +4,7 @@ import sys
 import json
 
 from counterpartylib.lib import script
-from counterpartylib.lib import config
+from counterpartylib.lib import config, util
 
 import requests
 from requests.exceptions import Timeout, ReadTimeout, ConnectionError
@@ -34,7 +34,7 @@ def rpc_call(payload):
                 logger.debug('Successfully connected.')
             break
         except (Timeout, ReadTimeout, ConnectionError):
-            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(url, i+1, TRIES))
+            logger.debug('Could not connect to backend at `{}`. (Try {}/{})'.format(util.clean_url_for_log(url), i+1, TRIES))
             time.sleep(5)
 
     if response == None:
@@ -42,7 +42,7 @@ def rpc_call(payload):
             network = 'testnet'
         else:
             network = 'mainnet'
-        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(url, network))
+        raise BackendRPCError('Cannot communicate with backend at `{}`. (server is set to run on {}, is backend?)'.format(util.clean_url_for_log(url), network))
     elif response.status_code not in (200, 500):
         raise BackendRPCError(str(response.status_code) + ' ' + response.reason)
 

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -13,6 +13,7 @@ from operator import itemgetter
 import fractions
 import warnings
 import binascii
+import re
 import hashlib
 import sha3
 import bitcoin as bitcoinlib
@@ -677,5 +678,14 @@ class DictCache:
     def refresh(self, key):
         with self.lock:
             self.dict.move_to_end(key, last=True)
+
+
+URL_USERNAMEPASS_REGEX = re.compile('.+://(.+)@')
+def clean_url_for_log(url):
+    m = URL_USERNAMEPASS_REGEX.match(url)
+    if m and m.group(1):
+        url = url.replace(m.group(1), 'XXXXXXXX')
+
+    return url
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -70,12 +70,17 @@ def get_lock():
     logger.debug('Lock acquired.')
 
 
-def initialise(database_file=None, log_file=None, api_log_file=None,
+def initialise(*args, **kwargs):
+    initialise_config(*args, **kwargs)
+    return initialise_db()
+
+
+def initialise_config(database_file=None, log_file=None, api_log_file=None,
                 testnet=False, testcoin=False,
                 backend_name=None, backend_connect=None, backend_port=None,
                 backend_user=None, backend_password=None,
                 backend_ssl=False, backend_ssl_no_verify=False,
-                backend_poll_interval=None, 
+                backend_poll_interval=None,
                 rpc_host=None, rpc_port=None,
                 rpc_user=None, rpc_password=None,
                 rpc_no_allow_cors=False,
@@ -340,6 +345,8 @@ def initialise(database_file=None, log_file=None, api_log_file=None,
 
     logger.info('Running v{} of counterparty-lib.'.format(config.VERSION_STRING))
 
+
+def initialise_db():
     if config.FORCE:
         logger.warning('THE OPTION `--force` IS NOT FOR USE ON PRODUCTION SYSTEMS.')
 

--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -2,6 +2,7 @@
 
 import os
 import decimal
+import pprint
 import sys
 import logging
 logger = logging.getLogger(__name__)
@@ -395,6 +396,15 @@ def reparse(db, block_index=None):
 
 def kickstart(db, bitcoind_dir):
     blocks.kickstart(db, bitcoind_dir=bitcoind_dir)
+
+
+def debug_config():
+    output = vars(config)
+    for k in list(output.keys()):
+        if k[:2] == "__" and k[-2:] == "__":
+            del output[k]
+
+    pprint.pprint(output)
 
 
 def generate_move_random_hash(move):


### PR DESCRIPTION
fixes: https://github.com/CounterpartyXCP/counterparty-lib/issues/835
belongs together with: https://github.com/CounterpartyXCP/counterparty-cli/pull/78

to make it possible to still easily debug the config options set, I've also added `debug_config` to `server`,  
and to make it quicker to just init the config without the DB I've seperated `initialise` into 2 functions.

 