### PR TITLE
stop executing tests in reverse order. 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,10 @@ test:
         - py.test --verbose --capture=no counterpartylib/test/unit_test.py
         - py.test --verbose --capture=no counterpartylib/test/parse_block_test.py
         - py.test --verbose --capture=no --skiptestbook=all counterpartylib/test/integration_test.py
+        - py.test --verbose --capture=no counterpartylib/test/contracts_test.py
         - py.test --verbose --capture=no --skiptestbook=mainnet -k test_book counterpartylib/test/reparse_test.py
         - py.test --verbose --capture=no --skiptestbook=testnet -k test_book counterpartylib/test/reparse_test.py
-        - py.test counterpartylib/test/contracts_test.py
+        - py.test --verbose --capture=no counterpartylib/test/database_version_test.py
 machine:
     pre:
         - mkdir -p ~/.local/share/counterparty;

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 # Keep this as non-docker for now, to give some variety to our test configurations, as travis builds with docker
 dependencies:
     override:
+        - rm -rf /home/ubuntu/virtualenvs/venv-3.4.1/bin/serpent
         - pip install -r requirements.txt
         - python setup.py install --with-serpent
 test:

--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -40,9 +40,6 @@ def enabled(change_name, block_index=None):
         return _enabled(change_name, block_index)
 util.enabled = enabled
 
-def pytest_collection_modifyitems(session, config, items):
-    """Run contracts_test.py last."""
-    items[:] = list(reversed(items))
 
 def pytest_generate_tests(metafunc):
     """Generate all py.test cases. Checks for different types of tests and creates proper context."""

--- a/counterpartylib/test/database_version_test.py
+++ b/counterpartylib/test/database_version_test.py
@@ -1,0 +1,34 @@
+#! /usr/bin/python3
+import tempfile
+import pytest
+
+from counterpartylib.test import conftest  # this is require near the top to do setup of the test suite
+from counterpartylib.test import util_test
+from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib import server
+from counterpartylib.lib import (config, check, database)
+
+
+def test_check_database_version():
+    server.initialise(database_file=tempfile.gettempdir() + '/fixtures.unittest.db', testnet=True, **util_test.COUNTERPARTYD_OPTIONS)
+    util_test.restore_database(config.DATABASE, CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql')
+    db = database.get_connection(read_only=False)
+    database.update_version(db)
+
+    version_major, version_minor = database.version(db)
+    assert config.VERSION_MAJOR == version_major
+    assert config.VERSION_MINOR == version_minor
+
+    check.database_version(db)
+
+    config.VERSION_MINOR += 1
+    with pytest.raises(check.DatabaseVersionError) as exception:
+        check.database_version(db)
+    assert exception.value.reparse_block_index == None
+    config.VERSION_MINOR -= 1
+
+    config.VERSION_MAJOR += 1
+    with pytest.raises(check.DatabaseVersionError) as exception:
+        check.database_version(db)
+    assert exception.value.reparse_block_index == config.BLOCK_FIRST
+    config.VERSION_MAJOR -= 1

--- a/counterpartylib/test/pytest.ini
+++ b/counterpartylib/test/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-python_files=integration_*.py
+python_files=*_test.py

--- a/counterpartylib/test/reparse_test.py
+++ b/counterpartylib/test/reparse_test.py
@@ -12,26 +12,3 @@ from counterpartylib.lib import (config, check, database)
 def test_book(testnet):
     """Reparse all the transactions in the database to see check blockhain's integrity."""
     util_test.reparse(testnet=testnet)
-
-
-def test_check_database_version():
-    server.initialise(database_file=tempfile.gettempdir() + '/fixtures.unittest.db', testnet=True, **util_test.COUNTERPARTYD_OPTIONS)
-    util_test.restore_database(config.DATABASE, CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql')
-    db = database.get_connection(read_only=False)
-    database.update_version(db)
-
-    version_major, version_minor = database.version(db)
-    assert config.VERSION_MAJOR == version_major
-    assert config.VERSION_MINOR == version_minor
-
-    check.database_version(db)
-
-    config.VERSION_MINOR += 1
-    with pytest.raises(check.DatabaseVersionError) as exception:
-        check.database_version(db)
-    assert exception.value.reparse_block_index == None
-
-    config.VERSION_MAJOR += 1
-    with pytest.raises(check.DatabaseVersionError) as exception:
-        check.database_version(db)
-    assert exception.value.reparse_block_index == config.BLOCK_FIRST


### PR DESCRIPTION
stop executing tests in reverse order, there's no good reason to ...

and properly detect test files hen letting pytest discover them (just for me when I run `pytest counterpartylib/test`).