### PR TITLE
add `disable_utxo_locks` 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,11 @@
 # Keep this as non-docker for now, to give some variety to our test configurations, as travis builds with docker
 dependencies:
     override:
-        - rm -rf /home/ubuntu/virtualenvs/venv-3.4.1/bin/serpent
+        - rm -rf /home/ubuntu/virtualenvs/venv-*/bin/serpent
+        - rm -rf /home/ubuntu/virtualenvs/venv-*/lib/python3.4/site-packages/apsw*
         - pip install -r requirements.txt
         - python setup.py install --with-serpent
+        - python -c "import apsw; print(apsw.apswversion())"
 test:
     override:
         - py.test --verbose --capture=no counterpartylib/test/unit_test.py

--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -68,7 +68,7 @@ API_TRANSACTIONS = ['bet', 'broadcast', 'btcpay', 'burn', 'cancel',
 COMMONS_ARGS = ['encoding', 'fee_per_kb', 'regular_dust_size',
                 'multisig_dust_size', 'op_return_value', 'pubkey',
                 'allow_unconfirmed_inputs', 'fee', 'fee_provided',
-                'unspent_tx_hash','custom_inputs']
+                'unspent_tx_hash', 'custom_inputs', 'dust_return_pubkey', 'disable_utxo_locks']
 
 API_MAX_LOG_SIZE = 10 * 1024 * 1024 #max log size of 20 MB before rotation (make configurable later)
 API_MAX_LOG_COUNT = 10
@@ -268,7 +268,7 @@ def compose_transaction(db, name, params,
                         allow_unconfirmed_inputs=False,
                         fee=None,
                         fee_provided=0,
-                        unspent_tx_hash=None, custom_inputs=None, dust_return_pubkey=None):
+                        unspent_tx_hash=None, custom_inputs=None, dust_return_pubkey=None, disable_utxo_locks=False):
     """Create and return a transaction."""
 
     # Get provided pubkeys.
@@ -294,13 +294,6 @@ def compose_transaction(db, name, params,
         if not script.is_fully_valid(binascii.unhexlify(pubkey)):
             raise script.AddressError('invalid public key: {}'.format(pubkey))
 
-    # copy and remove dust_return_pubkey from params into var
-    if 'dust_return_pubkey' in params:
-        if dust_return_pubkey is not None:
-            raise exceptions.ComposeError('dust_return_pubkey in params and as argument')
-        dust_return_pubkey = params.get('dust_return_pubkey')
-        del params['dust_return_pubkey']
-
     compose_method = sys.modules['counterpartylib.lib.messages.{}'.format(name)].compose
     compose_params = inspect.getargspec(compose_method)[0]
     missing_params = [p for p in compose_params if p not in params and p != 'db']
@@ -318,7 +311,8 @@ def compose_transaction(db, name, params,
                                         exact_fee=fee,
                                         fee_provided=fee_provided,
                                         unspent_tx_hash=unspent_tx_hash, custom_inputs=custom_inputs,
-                                        dust_return_pubkey=dust_return_pubkey)
+                                        dust_return_pubkey=dust_return_pubkey,
+                                        disable_utxo_locks=disable_utxo_locks)
 
 def conditional_decorator(decorator, condition):
     """Checks the condition and if True applies specified decorator."""

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -317,7 +317,7 @@ def construct (db, tx_info, encoding='auto',
                multisig_dust_size=config.DEFAULT_MULTISIG_DUST_SIZE,
                op_return_value=config.DEFAULT_OP_RETURN_VALUE,
                exact_fee=None, fee_provided=0, provided_pubkeys=None, dust_return_pubkey=None,
-               allow_unconfirmed_inputs=False, unspent_tx_hash=None, custom_inputs=None):
+               allow_unconfirmed_inputs=False, unspent_tx_hash=None, custom_inputs=None, disable_utxo_locks=False):
 
     global UTXO_LOCKS
 
@@ -499,7 +499,7 @@ def construct (db, tx_info, encoding='auto',
         raise exceptions.BalanceError('Insufficient {} at address {}. (Need approximately {} {}.) To spend unconfirmed coins, use the flag `--unconfirmed`. (Unconfirmed coins cannot be spent from multi‐sig addresses.)'.format(config.BTC, source, total_btc_out / config.UNIT, config.BTC))
 
     # Lock the source's inputs (UTXOs) chosen for this transaction
-    if UTXO_LOCKS is not None:
+    if UTXO_LOCKS is not None and not disable_utxo_locks:
         if source not in UTXO_LOCKS:
             UTXO_LOCKS[source] = cachetools.TTLCache(
                 UTXO_LOCKS_PER_ADDRESS_MAXSIZE, config.UTXO_LOCKS_MAX_AGE)


### PR DESCRIPTION
add `disable_utxo_locks` to `transaction.construct` and `compose_transaction` to disable the locking of selected UTXOs for when the 'user' doesn't intend to broadcast the TX (straight away).

for payment channels you want to compose a TX but don't broadcast it (straight away) and if the UTXOs are locked you'll run into insufficient balance errors if you compose multiple times in quick succession. 

depends on: https://github.com/CounterpartyXCP/counterparty-lib/pull/902