### PR TITLE
PROTOCOL CHANGE: first_input_is_source

### DIFF
--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -699,9 +699,12 @@ def get_tx_info2(tx_hex, block_parser=None, p2sh_support=False):
         else:
             raise DecodeError('unrecognised source type')
 
-        # Collect unique sources.
-        if new_source not in sources:
-            sources.append(new_source)
+        # old; append to sources, results in invalid addresses
+        # new; first found source is source, the rest can be anything (to fund the TX for example)
+        if not (util.enabled('first_input_is_source') and len(sources)):
+            # Collect unique sources.
+            if new_source not in sources:
+                sources.append(new_source)
 
     sources = '-'.join(sources)
     destinations = '-'.join(destinations)

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -82,5 +82,12 @@
         "minimum_version_revision": 0,
         "block_index": 500000,
         "testnet_block_index": 0
+    },
+	"first_input_is_source": {
+        "minimum_version_major": 9,
+        "minimum_version_minor": 55,
+        "minimum_version_revision": 0,
+        "block_index": 600000,
+        "testnet_block_index": 0
     }
 }

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -383,6 +383,26 @@ UNITTEST_VECTOR = {
                         5430,
                         10000,
                         b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
+            },
+            {
+                # 2 sources is actually invalid, but pre-first_input_is_source this was the consensus!
+                'mock_protocol_changes': {'first_input_is_source': False},
+                'comment': 'data in OP_CHECKMULTISIG script , without first_input_is_source, 2 sources',
+                'in': (b'0100000002ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff5ef833190e74ad47d8ae693f841a8b1b500ded7e23ee66b29898b72ec4914fdc0100000000ffffffff03361500000000000017a9144264cfd7eb65f8cbbdba98bd9815d5461fad8d7e87781e000000000000695121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753aed2fe7c11000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000',),
+                'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns-mnfAHmddVibnZNSkh8DvKaQoiEfNsxjXzH',
+                        '2MyJHMUenMWonC35Yi6PHC7i2tkS7PuomCy',
+                        5430,
+                        10000,
+                        b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
+            },
+            {
+                'comment': 'data in OP_CHECKMULTISIG script, with first_input_is_source, 1 source',
+                'in': (b'0100000002ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff5ef833190e74ad47d8ae693f841a8b1b500ded7e23ee66b29898b72ec4914fdc0100000000ffffffff03361500000000000017a9144264cfd7eb65f8cbbdba98bd9815d5461fad8d7e87781e000000000000695121035ca51ea175f108a1c63588683dc4c43a7146c46799f864a300263c0813f5fe352102309a14a1a30202f2e76f46acdb2917752371ca42b97460f7928ade8ecb02ea17210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753aed2fe7c11000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000',),
+                'out': ('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns',
+                        '2MyJHMUenMWonC35Yi6PHC7i2tkS7PuomCy',
+                        5430,
+                        10000,
+                        b'\x00\x00\x00(\x00\x00R\xbb3d\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x02\xfa\xf0\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x10\x00\x00\x00\n')
             }
         ],
         'get_tx_info1': [


### PR DESCRIPTION
any inputs after the first (that is identifiable as source) is ignored for sources.

before this change if a TX contained inputs from multiple addresses they'd be concatenated with a `-`, I think the author thought this could be a cool future feature, considering this is in the verification part:

```
    # Only one source and one destination allowed for now.
    if len(tx['source'].split('-')) > 1:
        return
    if tx['destination']:
        if len(tx['destination'].split('-')) > 1:
            return
```

removing this now so we're not constraint by this, if we ever want to have multiple sources / destinations it should be thought through more anyway! 

FYI: this only has happened twice in the history of CP, most likely someone making a mistake:
83491e9fff2936f75fcfb138515cbe8677b00a1f2399c564229bb6afbf482a70
8e566993a4da03996413f9c71b9342675bce453d445844e3bde8c39998281402