### PR TITLE
add ConfigContext, easy way to temporarly modify config (for testing)

### DIFF
--- a/counterpartylib/test/bytespersigop_test.py
+++ b/counterpartylib/test/bytespersigop_test.py
@@ -1,0 +1,26 @@
+#! /usr/bin/python3
+import pprint
+import tempfile
+from counterpartylib.test import conftest  # this is require near the top to do setup of the test suite
+from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP
+from counterpartylib.test.util_test import CURR_DIR
+
+from counterpartylib.lib import (blocks)
+
+
+FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/parseblock_unittest_fixture.sql'
+FIXTURE_DB = tempfile.gettempdir() + '/fixtures.parseblock_unittest_fixture.db'
+
+
+def test_parse_block(server_db):
+    test_outputs = blocks.parse_block(server_db, DP['default_block_index'], 1420914478)
+    outputs = ('baa1c5b432094ebc0d0d817db8e874e112d2cc539632a6754bce699e5fb1643f',
+               '72a73f5a73384114b1acb451e20ac98716ee44cb37b03404d341a4bfef8d0efc',
+               '0da70d5c8da450373de695385677d9428374cd3ee2715f39792664e1c5c73f58',
+               None)
+
+    try:
+        assert outputs == test_outputs
+    except AssertionError:
+        msg = "expected outputs don't match test_outputs:\noutputs=\n" + pprint.pformat(outputs) + "\ntest_outputs=\n" + pprint.pformat(test_outputs)
+        raise AssertionError(msg)

--- a/counterpartylib/test/config_context_test.py
+++ b/counterpartylib/test/config_context_test.py
@@ -6,14 +6,14 @@ from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP
 from counterpartylib.test import util_test
 from counterpartylib.test.util_test import CURR_DIR
 
-from counterpartylib.lib import (blocks, config)
+from counterpartylib.lib import (blocks, config, util)
 
 
 FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/parseblock_unittest_fixture.sql'
 FIXTURE_DB = tempfile.gettempdir() + '/fixtures.parseblock_unittest_fixture.db'
 
 
-def test_parse_block(cp_server):
+def test_config_context(cp_server):
     assert config.BTC_NAME == "Bitcoin"
 
     with util_test.ConfigContext(BTC_NAME="Bitcoin Testing"):
@@ -25,3 +25,17 @@ def test_parse_block(cp_server):
         assert config.BTC_NAME == "Bitcoin Testing"
 
     assert config.BTC_NAME == "Bitcoin"
+
+
+def test_mock_protocol_changes(cp_server):
+    assert util.enabled('multisig_addresses') == True
+
+    with util_test.MockProtocolChangesContext(multisig_addresses=False):
+        assert util.enabled('multisig_addresses') == False
+
+        with util_test.MockProtocolChangesContext(multisig_addresses=None):
+                assert util.enabled('multisig_addresses') == None
+
+        assert util.enabled('multisig_addresses') == False
+
+    assert util.enabled('multisig_addresses') == True

--- a/counterpartylib/test/config_context_test.py
+++ b/counterpartylib/test/config_context_test.py
@@ -1,0 +1,27 @@
+#! /usr/bin/python3
+import pprint
+import tempfile
+from counterpartylib.test import conftest  # this is require near the top to do setup of the test suite
+from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP
+from counterpartylib.test import util_test
+from counterpartylib.test.util_test import CURR_DIR
+
+from counterpartylib.lib import (blocks, config)
+
+
+FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/parseblock_unittest_fixture.sql'
+FIXTURE_DB = tempfile.gettempdir() + '/fixtures.parseblock_unittest_fixture.db'
+
+
+def test_parse_block(cp_server):
+    assert config.BTC_NAME == "Bitcoin"
+
+    with util_test.ConfigContext(BTC_NAME="Bitcoin Testing"):
+        assert config.BTC_NAME == "Bitcoin Testing"
+
+        with util_test.ConfigContext(BTC_NAME="Bitcoin Testing Testing"):
+            assert config.BTC_NAME == "Bitcoin Testing Testing"
+
+        assert config.BTC_NAME == "Bitcoin Testing"
+
+    assert config.BTC_NAME == "Bitcoin"

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -521,3 +521,28 @@ class ConfigContext(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         for k in self._before:
             vars(self.config)[k] = self._before[k]
+
+
+class MockProtocolChangesContext(object):
+    def __init__(self, **kwargs):
+        from counterpartylib.test.conftest import MOCK_PROTOCOL_CHANGES
+        self.mock_protocol_changes = MOCK_PROTOCOL_CHANGES
+        self._extend = kwargs
+        self._before = {}
+        self._before_empty = []
+
+    def __enter__(self):
+        self._before = {}
+        for k in self._extend:
+            if k in self.mock_protocol_changes:
+                self._before[k] = self.mock_protocol_changes[k]
+            else:
+                self._before_empty.append(k)
+
+            self.mock_protocol_changes[k] = self._extend[k]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for k in self._before:
+            self.mock_protocol_changes[k] = self._before[k]
+        for k in self._before_empty:
+            del self.mock_protocol_changes[k]

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -504,3 +504,20 @@ def reparse(testnet=True):
                 old_txlist = get_block_txlist(prod_db, block['block_index'])
                 compare_strings(old_txlist, new_txlist)
             raise(e)
+
+
+class ConfigContext(object):
+    def __init__(self, **kwargs):
+        self.config = config
+        self._extend = kwargs
+        self._before = {}
+
+    def __enter__(self):
+        self._before = {}
+        for k in self._extend:
+            self._before[k] = vars(self.config)[k]
+            vars(self.config)[k] = self._extend[k]
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for k in self._before:
+            vars(self.config)[k] = self._before[k]


### PR DESCRIPTION
adds `ConfigContext` and `MockProtocolChangesContext` with `__enter__` / `__exit__` magic to modify config / mock protocol changes for easy testing.