### PR TITLE
CORS headers tweak to allow auth from web clients

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -723,7 +723,8 @@ class APIServer(threading.Thread):
             if not config.RPC_NO_ALLOW_CORS:
                 response.headers['Access-Control-Allow-Origin'] = '*'
                 response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
-                response.headers['Access-Control-Allow-Headers'] = 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type'
+                response.headers['Access-Control-Allow-Headers'] = 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization'
+                response.headers['Access-Control-Allow-Credentials'] = 'true'
 
         @app.route('/', defaults={'args_path': ''}, methods=['GET', 'POST', 'OPTIONS'])
         @app.route('/<path:args_path>',  methods=['GET', 'POST', 'OPTIONS'])

--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -724,7 +724,6 @@ class APIServer(threading.Thread):
                 response.headers['Access-Control-Allow-Origin'] = '*'
                 response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
                 response.headers['Access-Control-Allow-Headers'] = 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization'
-                response.headers['Access-Control-Allow-Credentials'] = 'true'
 
         @app.route('/', defaults={'args_path': ''}, methods=['GET', 'POST', 'OPTIONS'])
         @app.route('/<path:args_path>',  methods=['GET', 'POST', 'OPTIONS'])


### PR DESCRIPTION
according to @jdogresorg:

> This will allow browsers to make XHR JSON-RPC requests to the counterparty API.
> Without this header change, the brower is not able to make XHR requests to a counterparty API which has a username/password set

@jdogresorg please test this and see if it addresses your issue. if so, I can merge
