### PR TITLE
Bytespersigop

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@
     * Updated python-bitcoinlib to newest version
     * No longer ceil the size of a transaction to KBs when calculating fees
     * Use dynamic estimated fee (from bitcoind)
+    * Fix for bytespersigop DoS protection in Bitcoin Core v0.12.1
     * Test suite:
         * Reorganization of the test suite at numerous points for more robustness and capabilities
         * Added ability to mock protocol changes to allow for testing of certain changes on or off

--- a/counterpartylib/lib/exceptions.py
+++ b/counterpartylib/lib/exceptions.py
@@ -39,4 +39,7 @@ class BTCOnlyError(MessageError):
 class BalanceError(Exception):
     pass
 
+class EncodingError(Exception):
+    pass
+
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -96,5 +96,12 @@
         "minimum_version_revision": 0,
         "block_index": 500000,
         "testnet_block_index": 861987
+    },
+    "bytespersigop": {
+        "minimum_version_major": 9,
+        "minimum_version_minor": 54,
+        "minimum_version_revision": 0,
+        "block_index": 500000,
+        "testnet_block_index": 0
     }
 }

--- a/counterpartylib/test/bytespersigop_test.py
+++ b/counterpartylib/test/bytespersigop_test.py
@@ -1,0 +1,144 @@
+import pprint
+import pytest
+import tempfile
+import bitcoin as bitcoinlib
+import binascii
+from counterpartylib.test import conftest  # this is require near the top to do setup of the test suite
+from counterpartylib.test.fixtures.params import DEFAULT_PARAMS as DP, ADDR
+from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib.test import util_test
+
+from counterpartylib.lib import (blocks, transaction, api, backend, util, exceptions)
+
+
+FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql'
+FIXTURE_DB = tempfile.gettempdir() + '/fixtures.unittest_fixture.db'
+
+
+def test_bytespersigop(server_db):
+    assert util.enabled('bytespersigop') == False
+
+    # ADDR[0], bytespersigop=False, desc 41 bytes, opreturn
+    txhex = api.compose_transaction(
+        server_db, 'issuance',
+        {'source': ADDR[0],
+         'asset': 'TESTING',
+         'quantity': 100,
+         'transfer_destination': None,
+         'divisible': False,
+         'description': 't' * 41},
+    )
+
+    tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+    assert len(tx.vin) == 1
+    assert len(tx.vout) == 2
+    assert "OP_RETURN" in repr(tx.vout[0].scriptPubKey)
+
+    # ADDR[0], bytespersigop=False, desc 42 bytes, multisig
+    txhex = api.compose_transaction(
+        server_db, 'issuance',
+        {'source': ADDR[0],
+         'asset': 'TESTING',
+         'quantity': 100,
+         'transfer_destination': None,
+         'divisible': False,
+         'description': 't' * 42},
+    )
+
+    tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+    assert len(tx.vin) == 1
+    assert len(tx.vout) == 3
+    assert "OP_CHECKMULTISIG" in repr(tx.vout[0].scriptPubKey)
+    assert "OP_CHECKMULTISIG" in repr(tx.vout[1].scriptPubKey)
+
+    # enable byterpersigop
+    with util_test.MockProtocolChangesContext(bytespersigop=True):
+        assert util.enabled('bytespersigop') == True
+
+        # ADDR[0], bytespersigop=True, desc 41 bytes, opreturn
+        txhex = api.compose_transaction(
+            server_db, 'issuance',
+            {'source': ADDR[0],
+             'asset': 'TESTING',
+             'quantity': 100,
+             'transfer_destination': None,
+             'divisible': False,
+             'description': 't' * 41},
+        )
+
+        tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+        assert len(tx.vin) == 1
+        assert len(tx.vout) == 2
+        assert "OP_RETURN" in repr(tx.vout[0].scriptPubKey)
+
+        # ADDR[0], bytespersigop=True, desc 42 bytes, pubkeyhash encoding
+        #  pubkeyhash because ADDR[0] only has 1 UTXO to spend from
+        txhex = api.compose_transaction(
+            server_db, 'issuance',
+            {'source': ADDR[0],
+             'asset': 'TESTING',
+             'quantity': 100,
+             'transfer_destination': None,
+             'divisible': False,
+             'description': 't' * 42},
+        )
+
+        tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+        assert len(tx.vin) == 1
+        assert len(tx.vout) == 8
+        for i in range(7):
+            assert "OP_CHECKSIG" in repr(tx.vout[i].scriptPubKey)
+
+        # ADDR[0], bytespersigop=True, desc 20 bytes, FORCED multisig encoding
+        #  will error because it's not possible, ADDR[0] only has 1 UTXO
+        with pytest.raises(exceptions.EncodingError):
+            txhex = api.compose_transaction(
+                server_db, 'issuance',
+                {'source': ADDR[0],
+                 'asset': 'TESTING',
+                 'quantity': 100,
+                 'transfer_destination': None,
+                 'divisible': False,
+             'description': 't' * 20},
+                encoding='multisig'
+            )
+
+        # ADDR[1], bytespersigop=True, desc 41 bytes, opreturn encoding
+        txhex = api.compose_transaction(
+            server_db, 'issuance',
+            {'source': ADDR[1],
+             'asset': 'TESTING',
+             'quantity': 100,
+             'transfer_destination': None,
+             'divisible': False,
+             'description': 't' * 41},
+        )
+
+        tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+        assert len(tx.vin) == 1
+        assert len(tx.vout) == 2
+        assert "OP_RETURN" in repr(tx.vout[0].scriptPubKey)
+
+        # ADDR[1], bytespersigop=True, desc 20 bytes, FORCED encoding=multisig
+        #  will use 2 UTXOs to make the bytes:sigop ratio in our favor
+        txhex = api.compose_transaction(
+            server_db, 'issuance',
+            {'source': ADDR[1],
+             'asset': 'TESTING',
+             'quantity': 100,
+             'transfer_destination': None,
+             'divisible': False,
+             'description': 't' * 20},
+            encoding='multisig'
+        )
+
+        tx = bitcoinlib.core.CTransaction.deserialize(binascii.unhexlify(txhex))
+
+        assert len(tx.vin) == 2
+        assert len(tx.vout) == 2
+        assert "OP_CHECKMULTISIG" in repr(tx.vout[0].scriptPubKey)

--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -22,7 +22,9 @@ from counterpartylib.lib import config, util, database, api
 
 
 # we swap out util.enabled with a custom one which has the option to mock the protocol changes
-MOCK_PROTOCOL_CHANGES = {}
+MOCK_PROTOCOL_CHANGES = {
+    'bytespersigop': False  # default to False to avoid all old vectors breaking
+}
 ALWAYS_LATEST_PROTOCOL_CHANGES = False
 _enabled = util.enabled
 def enabled(change_name, block_index=None):

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -611,6 +611,9 @@ UNITTEST_VECTOR = {
             'comment': 'test current text packing for LOCK',
             'in': (ADDR[0], 1388000100, 50000000, 0, 'LOCK'),
             'out': (ADDR[0], [], b'\x00\x00\x00\x1eR\xbb3dA\x87\xd7\x84\x00\x00\x00\x00\x00\x00\x00\x00\x04LOCK')
+        }, {
+            'in': (ADDR[0], 1588000000, 1, DP['fee_multiplier'], 'Over 80 characters test test test test test test test test test test test test test test test test test test'),
+            'out': (ADDR[0], [], b'\x00\x00\x00\x1e^\xa6\xf5\x00?\xf0\x00\x00\x00\x00\x00\x00\x00LK@lOver 80 characters test test test test test test test test test test test test test test test test test test')
         }],
         'parse': [{
             'comment': 'test old text unpacking for short text',
@@ -2672,6 +2675,16 @@ UNITTEST_VECTOR = {
             'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', None)], b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02\xfa\xf0\x80'), {'encoding': 'multisig'}),
             'out': '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff0336150000000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac781e0000000000006951210262415bf04af834423d3dd7ada4dc727a030865759f9fba5aee78c9ea71e58798210254da540fb2663b75e6c3cc61190ad0c2431643bab28ced783cd94079bbe72447210282b886c087eb37dc8182f14ba6cc3e9485ed618b95804d44aecc17c300b585b053ae840dea0b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
         }, {
+            'comment': 'send with multisig encoding and bytespersigop enabled',
+            'mock_protocol_changes': {'bytespersigop': True},
+            'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', None)], b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02\xfa\xf0\x80'), {'encoding': 'multisig'}),
+            'error': (exceptions.EncodingError, 'multisig will be rejected by Bitcoin Core >= v0.12.1, you should use `encoding=auto` or `encoding=pubkeyhash`')
+        }, {
+            'comment': 'send with multisig encoding and bytespersigop enabled for address with multiple UTXOs',
+            'mock_protocol_changes': {'bytespersigop': True},
+            'in': (('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', [('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', None)], b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02\xfa\xf0\x80'), {'encoding': 'multisig'}),
+            'out': '0100000002ebe3111881a8733ace02271dcf606b7450c41a48c1cb21fd73f4ba787b353ce4000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff85497c27fbc3ecfbfb41f49cbf983e252a91636ec92f2863cb7eb755a33afcb9000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88acffffffff0336150000000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac781e0000000000006951210372a51ea175f108a1c635886815c4c468ca75a06798f864a1fad446f893f5fef121023260e421a30202f2e76f46acdb292c652371ca48b97460f7928ade8ecb02ea66210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753aec2319f06000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000'
+        }, {
             'comment': 'send, different dust pubkey',
             'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [('mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns', None)], b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x02\xfa\xf0\x80'), {'encoding': 'multisig', 'dust_return_pubkey': '0319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b977'}),
             'out': '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff0336150000000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac781e0000000000006951210262415bf04af834423d3dd7ada4dc727a030865759f9fba5aee78c9ea71e58798210254da540fb2663b75e6c3cc61190ad0c2431643bab28ced783cd94079bbe72447210319f6e07b0b8d756156394b9dcf3b011fe9ac19f2700bd6b69a6a1783dbb8b97753ae840dea0b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
@@ -2767,6 +2780,15 @@ UNITTEST_VECTOR = {
             'comment': 'free issuance',
             'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [], b'\x00\x00\x00\x14\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x03\xe8\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'), {'encoding': 'multisig'}),
             'out': '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff02781e0000000000006951210259415bf04af834423d3dd7adb0238d85fcf79a8a619fba5aee7a331919e487e8210254da540fb2663b75e6c3cc61190ad0c2431643bab28ced783cd94079bbe72447210282b886c087eb37dc8182f14ba6cc3e9485ed618b95804d44aecc17c300b585b053ae0c26ea0b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
+        }, {
+            'comment': 'large broadcast',
+            'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [], b'\x00\x00\x00\x1e^\xa6\xf5\x00?\xf0\x00\x00\x00\x00\x00\x00\x00LK@lOver 80 characters test test test test test test test test test test test test test test test test test test'), {}),
+            'out': '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff04781e0000000000006951210343415bf04af834423d3dd7adba82d48f033795759e9fba5aee7a7f51b189c8c0210322bf262f8a561b168ea2be007a7eb5b0303637dfc1f8cd0c59aa3459cf825784210282b886c087eb37dc8182f14ba6cc3e9485ed618b95804d44aecc17c300b585b053ae781e0000000000006951210343415bf04af834423d49f7d9c1af065a776d1601beebdf299a5a477f8291a7c4210220bf277b92125e0692e3b8046a7ef0b62665379ac6e99e0c1cad250acfc750c9210282b886c087eb37dc8182f14ba6cc3e9485ed618b95804d44aecc17c300b585b053ae781e0000000000006951210361415bf04af834423d58a4d984a8170977281110edeb9a2e8b09473a8580f45d210220da540fb2663b75e6c3cc61190ad0c2431643bab28ced783cd94079bbe724dc210282b886c087eb37dc8182f14ba6cc3e9485ed618b95804d44aecc17c300b585b053ae4ad9e90b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
+        }, {
+            'comment': 'large broadcast with bytespersigop, which will force pubkeyhash encoding',
+            'mock_protocol_changes': {'bytespersigop': True},
+            'in': (('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc', [], b'\x00\x00\x00\x1e^\xa6\xf5\x00?\xf0\x00\x00\x00\x00\x00\x00\x00LK@lOver 80 characters test test test test test test test test test test test test test test test test test test'), {}),
+            'out': '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff0d36150000000000001976a9146d415bf04af834423d3dd7adba82d48f0337957588ac36150000000000001976a9146d415bf04af834423d3dd7ada4dc72364848093a88ac36150000000000001976a9146d415bf04af834423d4bb2df84e4425a6060040788ac36150000000000001976a9146d415bf04af834423d5cb4d9c1ae015a776d160188ac36150000000000001976a9146d415bf04af834423d1da3c8d7a8520e667b115588ac36150000000000001976a9146d415bf04af834423d49b2ded0fc061f707c450188ac36150000000000001976a9146d415bf04af834423d58a4d984a817097728111088ac36150000000000001976a9146d415bf04af834423d4ea38dd0b9010e237c000688ac36150000000000001976a9146d415bf04af834423d49f7d9c1af065a776d160188ac36150000000000001976a9146d415bf04af834423d1da3c8d7a8520e667b115588ac36150000000000001976a9146d415bf04af834423d49b2ded0fc061f707c450188ac36150000000000001976a9146e415bf04af834423d58a4d984a817097708657588ac0d26e90b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
         }],
     },
     'api': {


### PR DESCRIPTION
In Bitcoin Core v0.12.1 a PR was merged to add `-bytespersigop` which limits the ratio of sigops:bytes.  

Unfortunately this DoS protection uses the shortcut way of counting sigops which counts OP_CHECKMULTISIG as 20 sigops (the max allowed) and results in CP TXs that use multisig encoding not being relayed and mined by v0.12.1 nodes (when > 80 bytes it no longer fits in opreturn).  
The reason for counting it as 20 sigops is because that's how sigops are also counted for the max of 20k sigops in 1 blocks.

this is an edge case, there's been 250 CP TXs with > 80 bytes in the history of CP;
- of which 129 were of an experimental feature (rock paper scissors) which were only early on.
- 61 issuances (0.1% of all issuances), depending on the length of the description it sometimes tips over the 80 bytes.
- 57 broadcasts (0.7% of all broadcasts), with 'random' text, mostly people testing out the feature and Adam testing how much data he could embed in a transaction.

Essentially bare multisig is 'dead' unless you manage to tip the bytes:sigop ratio in your favor, which requires 2x as many non multisig inputs as multisig outputs / inputs combined.

This PR consists of 2 fallbacks to deal with this problem:

1. it will try to spend from extra UTXOs to tip the bytes:sigops ratio in our favor, 2x as many inputs as data outputs does the trick.
2. it will fallback to pubkeyhash encoding when the above isn't possible, unfortunately our last resort and a solution that will pollute the UTXO set... (P2SH encoding is in progress to replace this)
