### PR TITLE
Change pytest to 2.9.2 to match counterblock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ required_packages = [
     'pycoin==0.62',
     'pycrypto==2.6.1',
     'pysha3==0.3',
-    'pytest==2.9.1',
+    'pytest==2.9.2',
     'pytest-cov==2.2.1',
     'python-bitcoinlib==0.5.1',
     'requests==2.10.0',


### PR DESCRIPTION
See #940. 

Checks:
* Looked through counterparty-lib issues for 2.9.2 to see if there's a problem with it  (didn't find any)
* Pytest changelog for 2.9.2 has no incompatible changes from 2.9.1: http://doc.pytest.org/en/latest/changelog.html#id87