### PR TITLE
add support for .1 XCP fee on numeric assets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ## Library Versions ##
 * v9.55.2 (2017-02-16)
     * Implemented CIP-4 subassets (https://github.com/CounterpartyXCP/cips/blob/master/cip-0004.md)
+    * Added a .1 XCP fee for numeric asset issuance
 * v9.55.1 (2016-12-02)
     * Hotfix for integer overflow bug that caused a crash on mainnet block #441563
 * v9.55.0 (2016-07-11)

--- a/counterpartylib/lib/messages/issuance.py
+++ b/counterpartylib/lib/messages/issuance.py
@@ -180,11 +180,16 @@ def validate (db, source, destination, asset, quantity, divisible, callable_, ca
             cursor.close()
             if util.enabled('numeric_asset_names'):  # Protocol change.
                 if subasset_longname is not None and util.enabled('subassets'): # Protocol change.
-                    # subasset issuance is 0.25
+                    # subasset issuance is 0.25 XCP
                     fee = int(0.25 * config.UNIT)
                 elif len(asset) >= 13:
-                    fee = 0
+                    if util.enabled('numeric_asset_fees'):  # Protocol change.
+                        # numeric issuance is 0.1 XCP
+                        fee = int(0.10 * config.UNIT)
+                    else:
+                        fee = 0
                 else:
+                    # named issuance is 0.5 XCP
                     fee = int(0.5 * config.UNIT)
             elif block_index >= 291700 or config.TESTNET:     # Protocol change.
                 fee = int(0.5 * config.UNIT)

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -117,5 +117,12 @@
         "minimum_version_revision": 2,
         "block_index": 999999,
         "testnet_block_index": 0
+    },
+    "numeric_asset_fees": {
+        "minimum_version_major": 9,
+        "minimum_version_minor": 55,
+        "minimum_version_revision": 2,
+        "block_index": 999999,
+        "testnet_block_index": 0
     }
 }

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -1472,8 +1472,8 @@ UNITTEST_VECTOR = {
             'in': (ADDR[0], None, 'NOSATOSHI', 1000.5, True, False, None, None, '', None, None, DP['default_block_index']),
             'out': (0, 0.0, ['quantity must be in satoshis'], 0, '', True, None, None)
         }, {
-            'in': (ADDR[0], None, 'CALLPRICEFLOAT', 1000, True, False, None, 100.0, '', None, None, DP['default_block_index']),
-            'out': (0, 0.0, [], 0, '', True, False, None)
+            'in': (ADDR[0], None, 'CALLPRICEFLT', 1000, True, False, None, 100.0, '', None, None, DP['default_block_index']), # CALLPRICE AS FLOAT
+            'out': (0, 0.0, [], 50000000, '', True, False, None)
         }, {
             'in': (ADDR[0], None, 'CALLPRICEINT', 1000, True, False, None, 100, '', None, None, DP['default_block_index']),
             'out': (0, 0.0, [], 50000000, '', True, False, None)
@@ -1484,7 +1484,7 @@ UNITTEST_VECTOR = {
             'in': (ADDR[0], None, 'CALLDATEINT', 1000, True, False, 1409401723, None, '', None, None, DP['default_block_index']),
             'out': (0, 0.0, [], 50000000, '', True, False, None)
         }, {
-            'in': (ADDR[0], None, 'CALLDATEFLOAT', 1000, True, False, 0.9 * 1409401723, None, '', None, None, DP['default_block_index']),
+            'in': (ADDR[0], None, 'CALLDATEFLT', 1000, True, False, 0.9 * 1409401723, None, '', None, None, DP['default_block_index']), # CALL DATE AS FLOAT
             'out': (1268461550.7, 0.0, ['call_date must be epoch integer'], 0, '', True, None, None)
         }, {
             'in': (ADDR[0], None, 'CALLDATESTR', 1000, True, False, 'abc', None, '', None, None, DP['default_block_index']),
@@ -1803,7 +1803,7 @@ UNITTEST_VECTOR = {
                     'block_index': DP['default_block_index'],
                     'description': '',
                     'divisible': 1,
-                    'fee_paid': 0,
+                    'fee_paid': 10000000,
                     'issuer': 'mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc',
                     'locked': 0,
                     'quantity': 1000,
@@ -1827,7 +1827,7 @@ UNITTEST_VECTOR = {
                     'asset': 'XCP',
                     'block_index': DP['default_block_index'],
                     'event': '4188c1f7aaae56ce3097ef256cdbcb644dd43c84e237b4add4f24fd4848cb2c7',
-                    'quantity': 0,
+                    'quantity': 10000000,
                 }}
             ]
         }, {


### PR DESCRIPTION
I had to modify `CALLPRICEFLOAT` and `CALLDATEFLOAT` because their original names were >= 13 characters and raised an error on testsuite run (this was a latent bug the fee change uncovered)