### PR TITLE
necessary 9.55.2 hotfixes

### DIFF
--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -749,6 +749,11 @@ def reinitialise(db, block_index=None):
     if block_index:
         cursor.execute('''DELETE FROM transactions WHERE block_index > ?''', (block_index,))
         cursor.execute('''DELETE FROM blocks WHERE block_index > ?''', (block_index,))
+    elif config.TESTNET:  # block_index NOT specified and we are running testnet
+        # just blow away the consensus hashes with a full testnet reparse, as we could activate
+        # new features retroactively, which could otherwise lead to ConsensusError exceptions being raised.
+        logger.info("Testnet full reparse detected: Clearing all consensus hashes before performing reparse.")
+        cursor.execute('''UPDATE blocks SET ledger_hash = NULL, txlist_hash = NULL, messages_hash = NULL''')
 
     cursor.close()
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,6 +8,17 @@ if [ ! -d /counterparty-cli/counterparty_cli.egg-info ]; then
     cd /counterparty-cli; python3 setup.py develop; cd /
 fi
 
+#########
+# HACK: Use python-bitcoinlib snapshot version for testnet
+# TODO: REMOVE THIS ONCE https://github.com/petertodd/python-bitcoinlib/pull/112 IS MERGED!
+if [[ $PARAMS == *"testnet"* ]]; then
+  echo "TESTNET USE DETECTED -- GETTING python-bitcoinlib 0.7.1-SNAPSHOT"
+  rm -rf /usr/local/lib/python3.5/dist-packages/bitcoin /usr/local/lib/python3.5/dist-packages/python_bitcoinlib-*.dist-info
+  pip3 install --upgrade git+https://github.com/robby-dermody/python-bitcoinlib.git@422d6d2a3d4c5e6265ebcfcd0a9137d7f6a2f5c5#egg=python-bitcoinlib-0.7.0
+  #^ yes, we make it look like 0.7.0 (using version "0.7.1-SNAPSHOT" was causing all sorts of issues)
+fi
+#########
+
 # Bootstrap if the database does not exist (do this here to handle cases
 # where a volume is mounted over the share dir, like the fednode docker compose config does...)
 if [ ! -f /root/.local/share/counterparty/counterparty.db ]; then
@@ -24,16 +35,6 @@ fi
 # http://veithen.github.io/2014/11/16/sigterm-propagation.html
 : ${PARAMS:=""}
 : ${COMMAND:="start"}
-
-#########
-# HACK: Use python-bitcoinlib snapshot version for testnet
-# TODO: REMOVE THIS ONCE https://github.com/petertodd/python-bitcoinlib/pull/112 IS MERGED!
-if [[ $PARAMS == *"testnet"* ]]; then
-  echo "TESTNET USE DETECTED -- GETTING python-bitcoinlib 0.7.1-SNAPSHOT"
-  rm -rf /usr/local/lib/python3.5/dist-packages/bitcoin /usr/local/lib/python3.5/dist-packages/python_bitcoinlib-*.dist-info
-  pip3 install --upgrade git+https://github.com/VidaID/python-bitcoinlib.git@5cd34672d7085ca4d55693a1008101c02ceeb7e9#egg=python-bitcoinlib-0.7.1-SNAPSHOT
-fi
-#########
 
 trap 'kill -TERM $PID' TERM INT
 /usr/local/bin/counterparty-server ${PARAMS} ${COMMAND} &

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -14,7 +14,7 @@ fi
 if [[ $PARAMS == *"testnet"* ]]; then
   echo "TESTNET USE DETECTED -- GETTING python-bitcoinlib 0.7.1-SNAPSHOT"
   rm -rf /usr/local/lib/python3.5/dist-packages/bitcoin /usr/local/lib/python3.5/dist-packages/python_bitcoinlib-*.dist-info
-  pip3 install --upgrade git+https://github.com/robby-dermody/python-bitcoinlib.git@422d6d2a3d4c5e6265ebcfcd0a9137d7f6a2f5c5#egg=python-bitcoinlib-0.7.0
+  pip3 install --upgrade git+https://github.com/CounterpartyXCP/python-bitcoinlib.git@112d66b11cde30b9c7e10895f057baab13cc35ec#egg=python-bitcoinlib-0.7.0
   #^ yes, we make it look like 0.7.0 (using version "0.7.1-SNAPSHOT" was causing all sorts of issues)
 fi
 #########

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ setup_options = {
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Distributed Computing"
     ],
-    'download_url': 'https://github.com/CounterpartyXCP/counterparty-lib/releases/tag/v' + CURRENT_VERSION,
+    'download_url': 'https://github.com/CounterpartyXCP/counterparty-lib/releases/tag/' + CURRENT_VERSION,
     'provides': ['counterpartylib'],
     'packages': find_packages(),
     'zip_safe': False,

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ required_packages = [
     'pysha3==0.3',
     'pytest==2.9.2',
     'pytest-cov==2.2.1',
-    'python-bitcoinlib>=0.7.0,<0.7.1',
+    'python-bitcoinlib==0.7.0',
     'requests==2.10.0',
     'tendo==0.2.8',
     'xmltodict==0.10.1',

--- a/setup.py
+++ b/setup.py
@@ -202,10 +202,11 @@ class bdist_egg(_bdist_egg):
         self.execute(post_install, (self, False), msg="Running post install tasks")
 
 required_packages = [
+    'appdirs==1.4.0',
+    'setuptools-markdown==0.2',
     'python-dateutil==2.5.3',
     'Flask-HTTPAuth==3.1.2',
     'Flask==0.11',
-    'appdirs==1.4.0',
     'colorlog==2.7.0',
     'json-rpc==1.10.3',
     'pycoin==0.77',
@@ -248,7 +249,7 @@ setup_options = {
     'provides': ['counterpartylib'],
     'packages': find_packages(),
     'zip_safe': False,
-    'setup_requires': ['appdirs'],
+    'setup_requires': ['appdirs', 'setuptools-markdown'],
     'install_requires': required_packages,
     'include_package_data': True,
     'cmdclass': {
@@ -261,6 +262,5 @@ setup_options = {
 
 if sys.argv[1] == 'sdist':
     setup_options['long_description_markdown_filename'] = 'README.md'
-    setup_options['setup_requires'].append('setuptools-markdown')
 
 setup(**setup_options)


### PR DESCRIPTION
* Fixes for the whole python-bitcoinlib issue (fixed by cloning the repo, and setting the version to 0.7.0)
* Fixes setuptools missing package issue (python-markdown) that happened on my boxes
* Fixes reparse issue on testnet

Everything seems to be smooth now with these fixes.
