### PR TITLE
Rename docker-engine to docker-ce.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - sudo apt-get -y install python3 python3-pip
 - sudo pip3 install coveralls
 # upgrade docker, for build argument support
-- sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+- sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
 - docker version
 - docker ps -a
 # get the current PR and branch name


### PR DESCRIPTION
Build results of this PR is still blocked by another issues.
But this is obviously required to apply.

See also: https://github.com/travis-ci/docs-travis-ci-com/pull/1248