### PR TITLE
Use estimatesmartfee instead of deprecated estimatefee

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -69,7 +69,7 @@ API_TRANSACTIONS = ['bet', 'broadcast', 'btcpay', 'burn', 'cancel',
 COMMONS_ARGS = ['encoding', 'fee_per_kb', 'regular_dust_size',
                 'multisig_dust_size', 'op_return_value', 'pubkey',
                 'allow_unconfirmed_inputs', 'fee', 'fee_provided',
-                'estimate_fee_per_kb', 'estimate_fee_per_kb_nblocks',
+                'estimate_fee_per_kb', 'estimate_fee_per_kb_conf_target', 'estimate_fee_per_kb_mode',
                 'unspent_tx_hash', 'custom_inputs', 'dust_return_pubkey', 'disable_utxo_locks']
 
 API_MAX_LOG_SIZE = 10 * 1024 * 1024 #max log size of 20 MB before rotation (make configurable later)
@@ -304,7 +304,7 @@ def adjust_get_sends_results(query_result):
 def compose_transaction(db, name, params,
                         encoding='auto',
                         fee_per_kb=None,
-                        estimate_fee_per_kb=None, estimate_fee_per_kb_nblocks=config.ESTIMATE_FEE_NBLOCKS,
+                        estimate_fee_per_kb=None, estimate_fee_per_kb_conf_target=config.ESTIMATE_FEE_CONF_TARGET, estimate_fee_per_kb_mode=config.ESTIMATE_FEE_MODE,
                         regular_dust_size=config.DEFAULT_REGULAR_DUST_SIZE,
                         multisig_dust_size=config.DEFAULT_MULTISIG_DUST_SIZE,
                         op_return_value=config.DEFAULT_OP_RETURN_VALUE,
@@ -353,7 +353,7 @@ def compose_transaction(db, name, params,
     tx_info = compose_method(db, **params)
     return transaction.construct(db, tx_info, encoding=encoding,
                                         fee_per_kb=fee_per_kb,
-                                        estimate_fee_per_kb=estimate_fee_per_kb, estimate_fee_per_kb_nblocks=estimate_fee_per_kb_nblocks,
+                                        estimate_fee_per_kb=estimate_fee_per_kb, estimate_fee_per_kb_conf_target=estimate_fee_per_kb_conf_target,
                                         regular_dust_size=regular_dust_size,
                                         multisig_dust_size=multisig_dust_size,
                                         op_return_value=op_return_value,
@@ -622,8 +622,8 @@ class APIServer(threading.Thread):
             return block
 
         @dispatcher.add_method
-        def fee_per_kb(nblocks=config.ESTIMATE_FEE_NBLOCKS):
-            return backend.fee_per_kb(nblocks)
+        def fee_per_kb(conf_target=config.ESTIMATE_FEE_CONF_TARGET, mode=config.ESTIMATE_FEE_MODE):
+            return backend.fee_per_kb(conf_target, mode)
 
         @dispatcher.add_method
         def get_blocks(block_indexes, min_message_index=None):

--- a/counterpartylib/lib/backend/__init__.py
+++ b/counterpartylib/lib/backend/__init__.py
@@ -67,13 +67,14 @@ def extract_addresses(txhash_list):
     return BACKEND().extract_addresses(txhash_list)
 
 
-def fee_per_kb(nblocks):
+def fee_per_kb(conf_target, mode):
     """
-    :param nblocks:
+    :param conf_target:
+    :param mode:
     :return: fee_per_kb in satoshis, or None when unable to determine
     """
 
-    return BACKEND().fee_per_kb(nblocks)
+    return BACKEND().fee_per_kb(conf_target, mode)
 
 
 def refresh_unconfirmed_transactions_cache(mempool_txhash_list):

--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -244,7 +244,7 @@ def fee_per_kb(conf_target, mode):
     feeperkb = rpc('estimatesmartfee', [conf_target], mode)
 
     if feeperkb == 'Insufficient data or no feerate found':
-            return None
+        return None
 
     return int(feeperkb * config.UNIT)
 

--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -241,15 +241,9 @@ def fee_per_kb(conf_target, mode):
     :return: fee_per_kb in satoshis, or None when unable to determine
     """
 
-    # we need to loop because sometimes bitcoind can't estimate a certain conf_target
-    retry = 0
-    feeperkb = -1
-    while feeperkb == -1:
-        feeperkb = rpc('estimatesmartfee', [conf_target], mode)
-        conf_target += 1
-        retry += 1
+    feeperkb = rpc('estimatesmartfee', [conf_target], mode)
 
-        if retry > 10:
+    if feeperkb == 'Insufficient data or no feerate found':
             return None
 
     return int(feeperkb * config.UNIT)

--- a/counterpartylib/lib/backend/addrindex.py
+++ b/counterpartylib/lib/backend/addrindex.py
@@ -234,18 +234,19 @@ def getrawtransaction(tx_hash, verbose=False, skip_missing=False):
 def getrawmempool():
     return rpc('getrawmempool', [])
 
-def fee_per_kb(nblocks):
+def fee_per_kb(conf_target, mode):
     """
-    :param nblocks:
+    :param conf_target:
+    :param mode:
     :return: fee_per_kb in satoshis, or None when unable to determine
     """
 
-    # we need to loop because sometimes bitcoind can't estimate a certain nblocks
+    # we need to loop because sometimes bitcoind can't estimate a certain conf_target
     retry = 0
     feeperkb = -1
     while feeperkb == -1:
-        feeperkb = rpc('estimatefee', [nblocks])
-        nblocks += 1
+        feeperkb = rpc('estimatesmartfee', [conf_target], mode)
+        conf_target += 1
         retry += 1
 
         if retry > 10:

--- a/counterpartylib/lib/backend/btcd.py
+++ b/counterpartylib/lib/backend/btcd.py
@@ -100,7 +100,7 @@ def unconfirmed_transactions():
 def refresh_unconfirmed_transactions_cache():
     raise NotImplementedError
 
-def fee_per_kb(nblocks):
+def fee_per_kb(conf_target, mode):
     raise NotImplementedError
 
 def getblockcount():

--- a/counterpartylib/lib/config.py
+++ b/counterpartylib/lib/config.py
@@ -85,8 +85,9 @@ DEFAULT_REGULAR_DUST_SIZE = 5430         # TODO: This is just a guess. I got it 
 DEFAULT_MULTISIG_DUST_SIZE = 7800        # <https://bitcointalk.org/index.php?topic=528023.msg7469941#msg7469941>
 DEFAULT_OP_RETURN_VALUE = 0
 DEFAULT_FEE_PER_KB = 25000               # sane/low default, also used as minimum when estimated fee is used
-ESTIMATE_FEE_PER_KB = True               # when True will use `estimatefee` from bitcoind instead of DEFAULT_FEE_PER_KB
-ESTIMATE_FEE_NBLOCKS = 3
+ESTIMATE_FEE_PER_KB = True               # when True will use `estimatesmartfee` from bitcoind instead of DEFAULT_FEE_PER_KB
+ESTIMATE_FEE_CONF_TARGET = 3
+ESTIMATE_FEE_MODE = 'CONSERVATIVE'
 
 # UI defaults
 DEFAULT_FEE_FRACTION_REQUIRED = .009   # 0.90%

--- a/counterpartylib/lib/transaction.py
+++ b/counterpartylib/lib/transaction.py
@@ -313,7 +313,7 @@ def make_outkey(output):
 
 def construct (db, tx_info, encoding='auto',
                fee_per_kb=config.DEFAULT_FEE_PER_KB,
-               estimate_fee_per_kb=None, estimate_fee_per_kb_nblocks=config.ESTIMATE_FEE_NBLOCKS,
+               estimate_fee_per_kb=None, estimate_fee_per_kb_conf_target=config.ESTIMATE_FEE_CONF_TARGET, estimate_fee_per_kb_mode=config.ESTIMATE_FEE_MODE,
                regular_dust_size=config.DEFAULT_REGULAR_DUST_SIZE,
                multisig_dust_size=config.DEFAULT_MULTISIG_DUST_SIZE,
                op_return_value=config.DEFAULT_OP_RETURN_VALUE,
@@ -472,7 +472,7 @@ def construct (db, tx_info, encoding='auto',
 
     # use backend estimated fee_per_kb
     if estimate_fee_per_kb:
-        estimated_fee_per_kb = backend.fee_per_kb(estimate_fee_per_kb_nblocks)
+        estimated_fee_per_kb = backend.fee_per_kb(estimate_fee_per_kb_conf_target, estimate_fee_per_kb_mode)
         if estimated_fee_per_kb is not None:
             fee_per_kb = max(estimated_fee_per_kb, fee_per_kb)  # never drop below the default fee_per_kb
 

--- a/counterpartylib/test/estimate_fee_per_kb_test.py
+++ b/counterpartylib/test/estimate_fee_per_kb_test.py
@@ -20,7 +20,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_estimate_fee_per_kb(fee_per_kb, fee_per_kb_used, server_db, monkeypatch):
-    def _fee_per_kb(nblocks):
+    def _fee_per_kb(conf_target, mode):
         return fee_per_kb
 
     monkeypatch.setattr('counterpartylib.lib.backend.fee_per_kb', _fee_per_kb)


### PR DESCRIPTION
Taking a shot at Issue #997.

Changes config value ESTIMATE_FEE_NBLOCKS to ESTIMATE_FEE_CONF_TARGET and add a ESTIMATE_FEE_MODE config value, cascades these changes through the code to use estimatesmartfee.