### PR TITLE
Stop downloading bootstrap DB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,6 @@ COPY docker/start.sh /usr/local/bin/start.sh
 RUN chmod a+x /usr/local/bin/start.sh
 WORKDIR /
 
-# Pull the mainnet and testnet DB boostraps
-RUN counterparty-server bootstrap --quiet
-RUN counterparty-server --testnet bootstrap --quiet
-
 EXPOSE 4000 14000
 
 # NOTE: Defaults to running on mainnet, specify -e TESTNET=1 to start up on testnet


### PR DESCRIPTION
They will be downloaded by start.sh called at starting the container.
It's better the container is thin.

And they will destroy database by calling `fednode rebuild` on the running node.