### PR TITLE
Make Address Options Bitwise

### DIFF
--- a/counterpartylib/lib/exceptions.py
+++ b/counterpartylib/lib/exceptions.py
@@ -42,4 +42,7 @@ class BalanceError(Exception):
 class EncodingError(Exception):
     pass
 
+class OptionsError(Exception):
+    pass
+
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/counterpartylib/lib/messages/broadcast.py
+++ b/counterpartylib/lib/messages/broadcast.py
@@ -210,7 +210,7 @@ def parse (db, tx, message):
     # Options? Should not fail to parse due to above checks.
     if util.enabled('options_require_memo') and text and text.lower().startswith('options'):
         options = util.parse_options_from_string(text)
-        if options if not False:
+        if options is not False:
             op_bindings = {
                         'block_index': tx['block_index'],
                         'address': tx['source'],

--- a/counterpartylib/lib/messages/broadcast.py
+++ b/counterpartylib/lib/messages/broadcast.py
@@ -108,7 +108,7 @@ def validate (db, source, timestamp, value, fee_fraction_int, text, block_index)
         try:
             # Check for options and if they are valid.
             options = util.parse_options_from_string(text)
-            if options or options is 0:
+            if options is not False:
                 util.validate_address_options(options)
         except exceptions.OptionsError as e:
             problems.append(str(e))
@@ -210,7 +210,7 @@ def parse (db, tx, message):
     # Options? Should not fail to parse due to above checks.
     if util.enabled('options_require_memo') and text and text.lower().startswith('options'):
         options = util.parse_options_from_string(text)
-        if options or options is 0:
+        if options if not False:
             op_bindings = {
                         'block_index': tx['block_index'],
                         'address': tx['source'],

--- a/counterpartylib/lib/messages/broadcast.py
+++ b/counterpartylib/lib/messages/broadcast.py
@@ -105,17 +105,13 @@ def validate (db, source, timestamp, value, fee_fraction_int, text, block_index)
             problems.append('text too long')
 
     if util.enabled('options_require_memo') and text and text.lower().startswith('options'):
-        ops_spl = text.split(" ")
-        if len(ops_spl) == 2:
-            try:
-                options_int = int(ops_spl.pop())
-
-                if (options_int > config.MAX_INT) or (options_int < 0):
-                    problems.append('integer overflow')
-                elif options_int > config.ADDRESS_OPTION_MAX_VALUE:
-                    problems.append('options out of range')
-            except:
-                problems.append('options not an integer')
+        try:
+            # Check for options and if they are valid.
+            options = util.parse_options_from_string(text)
+            if options:
+                util.validate_address_options(options)
+        except exceptions.OptionsError as e:
+            problems.append(e)
 
     return problems
 
@@ -211,28 +207,18 @@ def parse (db, tx, message):
     if util.enabled('broadcast_invalid_check') and status != 'valid':
         return
 
-    # Options? if the status is invalid the previous if should have catched it
-    if util.enabled('options_require_memo'):
-        if text and text.lower().startswith('options'):
-            ops_spl = text.split(" ")
-            if len(ops_spl) == 2:
-                change_ops = False
-                options_int = 0
-                try:
-                    options_int = int(ops_spl.pop())
-                    change_ops = True
-                except:
-                    pass
-
-                if change_ops:
-                    op_bindings = {
-                                'block_index': tx['block_index'],
-                                'address': tx['source'],
-                                'options': options_int
-                               }
-                    sql = 'insert or replace into addresses(address, options, block_index) values(:address, :options, :block_index)'
-                    cursor = db.cursor()
-                    cursor.execute(sql, op_bindings)
+    # Options? Should not fail to parse due to above checks.
+    if util.enabled('options_require_memo') and text and text.lower().startswith('options'):
+        options = util.parse_options_from_string(text)
+        if options:
+            op_bindings = {
+                        'block_index': tx['block_index'],
+                        'address': tx['source'],
+                        'options': options
+                       }
+            sql = 'insert or replace into addresses(address, options, block_index) values(:address, :options, :block_index)'
+            cursor = db.cursor()
+            cursor.execute(sql, op_bindings)
 
     # Negative values (default to ignore).
     if value is None or value < 0:

--- a/counterpartylib/lib/messages/broadcast.py
+++ b/counterpartylib/lib/messages/broadcast.py
@@ -108,7 +108,7 @@ def validate (db, source, timestamp, value, fee_fraction_int, text, block_index)
         try:
             # Check for options and if they are valid.
             options = util.parse_options_from_string(text)
-            if options:
+            if options or options is 0:
                 util.validate_address_options(options)
         except exceptions.OptionsError as e:
             problems.append(str(e))
@@ -210,7 +210,7 @@ def parse (db, tx, message):
     # Options? Should not fail to parse due to above checks.
     if util.enabled('options_require_memo') and text and text.lower().startswith('options'):
         options = util.parse_options_from_string(text)
-        if options:
+        if options or options is 0:
             op_bindings = {
                         'block_index': tx['block_index'],
                         'address': tx['source'],

--- a/counterpartylib/lib/messages/broadcast.py
+++ b/counterpartylib/lib/messages/broadcast.py
@@ -111,7 +111,7 @@ def validate (db, source, timestamp, value, fee_fraction_int, text, block_index)
             if options:
                 util.validate_address_options(options)
         except exceptions.OptionsError as e:
-            problems.append(e)
+            problems.append(str(e))
 
     return problems
 

--- a/counterpartylib/lib/messages/versions/enhanced_send.py
+++ b/counterpartylib/lib/messages/versions/enhanced_send.py
@@ -83,7 +83,7 @@ def validate (db, source, destination, asset, quantity, memo_bytes, block_index)
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+                if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     if memo_bytes is None or (len(memo_bytes) == 0):
                         problems.append('destination requires memo')
         finally:

--- a/counterpartylib/lib/messages/versions/enhanced_send.py
+++ b/counterpartylib/lib/messages/versions/enhanced_send.py
@@ -83,7 +83,7 @@ def validate (db, source, destination, asset, quantity, memo_bytes, block_index)
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and result['options'] & config.ADDRESS_OPTION_REQUIRE_MEMO:
+                if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     if memo_bytes is None or (len(memo_bytes) == 0):
                         problems.append('destination requires memo')
         finally:

--- a/counterpartylib/lib/messages/versions/enhanced_send.py
+++ b/counterpartylib/lib/messages/versions/enhanced_send.py
@@ -83,7 +83,7 @@ def validate (db, source, destination, asset, quantity, memo_bytes, block_index)
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+                if result and util.active_options(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     if memo_bytes is None or (len(memo_bytes) == 0):
                         problems.append('destination requires memo')
         finally:

--- a/counterpartylib/lib/messages/versions/send1.py
+++ b/counterpartylib/lib/messages/versions/send1.py
@@ -58,7 +58,7 @@ def validate (db, source, destination, asset, quantity, block_index):
         results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
         if results:
             result = results.fetchone()
-            if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+            if result and util.active_options(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                 problems.append('destination requires memo')
         cursor.close()
 

--- a/counterpartylib/lib/messages/versions/send1.py
+++ b/counterpartylib/lib/messages/versions/send1.py
@@ -58,7 +58,7 @@ def validate (db, source, destination, asset, quantity, block_index):
         results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
         if results:
             result = results.fetchone()
-            if result and result['options'] & config.ADDRESS_OPTION_REQUIRE_MEMO:
+            if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                 problems.append('destination requires memo')
         cursor.close()
 

--- a/counterpartylib/lib/messages/versions/send1.py
+++ b/counterpartylib/lib/messages/versions/send1.py
@@ -58,7 +58,7 @@ def validate (db, source, destination, asset, quantity, block_index):
         results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
         if results:
             result = results.fetchone()
-            if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+            if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                 problems.append('destination requires memo')
         cursor.close()
 

--- a/counterpartylib/lib/messages/versions/send2.py
+++ b/counterpartylib/lib/messages/versions/send2.py
@@ -80,7 +80,7 @@ def validate(db, source, destination, asset, quantity, block_index):
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and result['options'] & config.ADDRESS_OPTION_REQUIRE_MEMO:
+                if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     raise ValidateError('destination requires memo')
         finally:
             cursor.close()

--- a/counterpartylib/lib/messages/versions/send2.py
+++ b/counterpartylib/lib/messages/versions/send2.py
@@ -80,7 +80,7 @@ def validate(db, source, destination, asset, quantity, block_index):
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and confirm_option_is_active(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+                if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     raise ValidateError('destination requires memo')
         finally:
             cursor.close()

--- a/counterpartylib/lib/messages/versions/send2.py
+++ b/counterpartylib/lib/messages/versions/send2.py
@@ -80,7 +80,7 @@ def validate(db, source, destination, asset, quantity, block_index):
             results = cursor.execute('SELECT options FROM addresses WHERE address=?', (destination,))
             if results:
                 result = results.fetchone()
-                if result and util.active_option(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
+                if result and util.active_options(result['options'], config.ADDRESS_OPTION_REQUIRE_MEMO):
                     raise ValidateError('destination requires memo')
         finally:
             cursor.close()

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -335,12 +335,12 @@ def validate_address_options(options):
         raise exceptions.OptionsError('options integer overflow')
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
-    elif not active_option(config.ADDRESS_OPTION_MAX_VALUE, options):
+    elif not active_options(config.ADDRESS_OPTION_MAX_VALUE, options):
         raise exceptions.OptionsError('options not possible')
 
-def active_option(config, option):
-    """Checks if option active in some given config."""
-    return config & option == option
+def active_options(config, options):
+    """Checks if options active in some given config."""
+    return config & options == options
 
 class DebitError (Exception): pass
 def debit (db, address, asset, quantity, action=None, event=None):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -338,9 +338,9 @@ def validate_address_options(options):
     elif not active_option(config.ADDRESS_OPTION_MAX_VALUE, options):
         raise exceptions.OptionsError('options not possible')
 
-def active_option(options, option):
-    """Checks if option present in options."""
-    return options & option == option
+def active_option(config, option):
+    """Checks if option active in some given config."""
+    return config & option == option
 
 class DebitError (Exception): pass
 def debit (db, address, asset, quantity, action=None, event=None):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -335,7 +335,7 @@ def validate_address_options(options):
         raise exceptions.OptionsError('options integer overflow')
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
-    elif options != 0 and config.ADDRESS_OPTION_MAX_VALUE & options != options:
+    elif not active_option(config.ADDRESS_OPTION_MAX_VALUE, options):
         raise exceptions.OptionsError('options not possible')
 
 def active_option(options, option):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -335,7 +335,7 @@ def validate_address_options(options):
         raise exceptions.OptionsError('options integer overflow')
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
-    elif config.ADDRESS_OPTION_MAX_VALUE & options == options
+    elif config.ADDRESS_OPTION_MAX_VALUE & options == options:
         raise exceptions.OptionsError('options not possible')
 
 def active_option(options, option):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -335,7 +335,7 @@ def validate_address_options(options):
         raise exceptions.OptionsError('options integer overflow')
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
-    elif config.ADDRESS_OPTION_MAX_VALUE & options == options:
+    elif config.ADDRESS_OPTION_MAX_VALUE & options != options:
         raise exceptions.OptionsError('options not possible')
 
 def active_option(options, option):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -338,6 +338,9 @@ def validate_address_options(options):
     elif config.ADDRESS_OPTION_MAX_VALUE & options == options
         raise exceptions.OptionsError('options not enabled')
 
+def confirm_option_is_active(options, option)
+    return options & option == option
+
 class DebitError (Exception): pass
 def debit (db, address, asset, quantity, action=None, event=None):
     """Debit given address by quantity of asset."""

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -317,6 +317,27 @@ def expand_subasset_longname(raw_bytes):
 def generate_random_asset ():
     return 'A' + str(random.randint(26**12 + 1, 2**64 - 1))
 
+def parse_options_from_string(string):
+    """Parse options integer from string, if exists."""
+    string_list = string.split(" ")
+    if len(string_list) == 2:
+        try:
+            options = int(string_list.pop())
+        except:
+            raise exceptions.OptionsError('options not an integer')
+        return options
+    else:
+        return False
+
+def validate_address_options(options):
+    """Ensure the options are all valid and in range."""
+    if (options > config.MAX_INT) or (options < 0):
+        raise exceptions.OptionsError('options integer overflow')
+    elif options > config.ADDRESS_OPTION_MAX_VALUE:
+        raise exceptions.OptionsError('options out of range')
+    elif config.ADDRESS_OPTION_MAX_VALUE & options == options
+        raise exceptions.OptionsError('options not enabled')
+
 class DebitError (Exception): pass
 def debit (db, address, asset, quantity, action=None, event=None):
     """Debit given address by quantity of asset."""

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -335,7 +335,7 @@ def validate_address_options(options):
         raise exceptions.OptionsError('options integer overflow')
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
-    elif config.ADDRESS_OPTION_MAX_VALUE & options != options:
+    elif options != 0 and config.ADDRESS_OPTION_MAX_VALUE & options != options:
         raise exceptions.OptionsError('options not possible')
 
 def active_option(options, option):

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -338,7 +338,8 @@ def validate_address_options(options):
     elif config.ADDRESS_OPTION_MAX_VALUE & options == options
         raise exceptions.OptionsError('options not enabled')
 
-def confirm_option_is_active(options, option)
+def active_option(options, option):
+    """Checks if option present in options."""
     return options & option == option
 
 class DebitError (Exception): pass

--- a/counterpartylib/lib/util.py
+++ b/counterpartylib/lib/util.py
@@ -336,7 +336,7 @@ def validate_address_options(options):
     elif options > config.ADDRESS_OPTION_MAX_VALUE:
         raise exceptions.OptionsError('options out of range')
     elif config.ADDRESS_OPTION_MAX_VALUE & options == options
-        raise exceptions.OptionsError('options not enabled')
+        raise exceptions.OptionsError('options not possible')
 
 def active_option(options, option):
     """Checks if option present in options."""

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -558,17 +558,17 @@ UNITTEST_VECTOR = {
             'comment': 'test changing options to ADDRESS_OPTION_MAX_VALUE + 1 on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS %i' % (config.ADDRESS_OPTION_MAX_VALUE+1), DP['default_block_index']),
-            'out': (['options out of range'])
+            'error': (exceptions.OptionsError, 'options out of range')
         }, {
             'comment': 'test changing options to -1 on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS -1', DP['default_block_index']),
-            'out': (['integer overflow'])
+            'error': (exceptions.OptionsError, 'options integer overflow')
         }, {
             'comment': 'test changing options to non-int on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS XCP', DP['default_block_index']),
-            'out': (['options not an integer'])
+            'error': (exceptions.OptionsError, 'options not an integer')
         }],
         'compose': [{
             'comment': 'test old text packing for short text',

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -558,17 +558,17 @@ UNITTEST_VECTOR = {
             'comment': 'test changing options to ADDRESS_OPTION_MAX_VALUE + 1 on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS %i' % (config.ADDRESS_OPTION_MAX_VALUE+1), DP['default_block_index']),
-            'error': (exceptions.OptionsError, 'options out of range')
+            'out': (['options out of range'])
         }, {
             'comment': 'test changing options to -1 on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS -1', DP['default_block_index']),
-            'error': (exceptions.OptionsError, 'options integer overflow')
+            'out': (['options integer overflow'])
         }, {
             'comment': 'test changing options to non-int on a specific address',
             'mock_protocol_changes': {'enhanced_sends': True, 'options_require_memo': True},
             'in': (ADDR[5], 1588000000, 1, DP['fee_multiplier'], 'OPTIONS XCP', DP['default_block_index']),
-            'error': (exceptions.OptionsError, 'options not an integer')
+            'out': (['options not an integer'])
         }],
         'compose': [{
             'comment': 'test old text packing for short text',


### PR DESCRIPTION
The design of [CIP 12](https://github.com/CounterpartyXCP/cips/blob/master/cip-0012.md) and the SQLite database are setup to support bitwise address options, but the current checks in place are not sufficient to support multiple address options. This PR is designed to change that.

This pull request does three things:
1. Treats options as a bitwise flag. Current code is more or less boolean.
2. Refactors parts of the code to better support additional address options.
3. Creates reusable utility functions for parsing, validating, and confirming options.

I don't work with bitwise flags often, but my understanding is that the current code only evaluates whether options are within a given range which leaves room for non-existent options to be set and the current checks in place assume the only option present will be ```config.ADDRESS_OPTION_REQUIRE_MEMO```.

For example, given ```config.ADDRESS_OPTION_MAX_VALUE=(1 | 2 | 4 | 16)```. If you were to set your address to have ```options=8``` or ```options=9```, the code would incorrectly permit these non-existent configurations.

Or, if your address showed ```options=3```, the current code would think your address wasn't requiring memos, when it was, because ```1 != 3```, but that's not how you evaluate a bitwise flag.

There is nothing necessarily wrong with how the code currently works, but the goal of this PR is to give us the option of multiple address options AND some of these utility functions could be reused, if we were to have asset options set through issuances, similar to the way locking works.

A good resource for understanding bitwise vs booleans:
https://stovepipe.systems/post/using-bitwise-instead-of-booleans