### PR TITLE
Remove redundant bitcoinlib.SetParams()

### DIFF
--- a/counterpartylib/server.py
+++ b/counterpartylib/server.py
@@ -146,9 +146,6 @@ def initialise_config(database_file=None, log_file=None, api_log_file=None,
     if config.TESTCOIN:
         network += '.testcoin'
 
-
-    bitcoinlib.SelectParams('testnet' if config.TESTNET else 'mainnet')
-
     # Database
     if database_file:
         config.DATABASE = database_file


### PR DESCRIPTION
You can't set to use regtest network if this line exists.