### PR TITLE
fix: address_scriptpubkey return wrong scriptpubkey of p2sh addr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ profile.txt
 
 # Cache folders
 .cache
+
+.python-version

--- a/counterpartylib/lib/backend/addrindexrs.py
+++ b/counterpartylib/lib/backend/addrindexrs.py
@@ -13,6 +13,7 @@ import collections
 import binascii
 import hashlib
 import signal
+import bitcoin.wallet
 
 from counterpartylib.lib import config, util, address
 
@@ -358,11 +359,8 @@ def _script_pubkey_to_hash(spk):
     return hashlib.sha256(spk).digest()[::-1].hex()
 
 def _address_to_hash(addr):
-    pk = address.address_scriptpubkey(addr)
-    #if pk[0:3] ==  b'\x76\xa9\x14':
-    #    pk = b''.join([pk[0:3], pk[4:-6], pk[-2:]])
-
-    return _script_pubkey_to_hash(pk)
+    script_pubkey = bitcoin.wallet.CBitcoinAddress(addr).to_scriptPubKey()
+    return _script_pubkey_to_hash(script_pubkey)
 
 # Returns an array of UTXOS from an address in the following format
 # {


### PR DESCRIPTION
**Problem**:  Current code not cover p2sh address then return wrong get_unspent_utxos list: 

```python
def address_scriptpubkey(address):
    try:
        bech32 = bitcoin.bech32.CBech32Data(address)
        return b''.join([b'\x00\x14', bech32.to_bytes()])
    except Exception as e:
        bs58 = bitcoin.base58.decode(address)[1:-4]
        return b''.join([b'\x76\xa9\x14', bs58, b'\x88\xac'])
```

**Solution**:

```python
import bitcoin.wallet
import hashlib

script_pubkey1 = bitcoin.wallet.CBitcoinAddress('37a9EQwNqA4Q3id7z3FXc1oEZoYhioLzHw').to_scriptPubKey()
script_pubkey2 = bitcoin.wallet.CBitcoinAddress('1AuGvfDfNhbeVNUDzXHjLmEnFnWv3pkjjG').to_scriptPubKey()
script_pubkey3 = bitcoin.wallet.CBitcoinAddress('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq').to_scriptPubKey()

hashlib.sha256(script_pubkey1).digest()[::-1].hex() # 6695a05566a0ab42ee1a3f6ea82cc6261befee183a286cebaee3674179848aee

hashlib.sha256(script_pubkey2).digest()[::-1].hex() # d2bfaec7aee1764d4fb67e328499d61bbacff806dbc26db641372a2f4c218dc8
hashlib.sha256(script_pubkey3).digest()[::-1].hex() # f8d3a7f6141fb7c08d0fc5597dcf754093a908cafcbe4c17cedbbe91ff41f39c
```