### PR TITLE
fix: string indices must be integers

### DIFF
--- a/counterpartylib/lib/backend/__init__.py
+++ b/counterpartylib/lib/backend/__init__.py
@@ -217,7 +217,8 @@ def pubkeyhash_to_pubkey(pubkeyhash, provided_pubkeys=None):
 
     # Search blockchain.
     raw_transactions = search_raw_transactions(pubkeyhash, unconfirmed=True)
-    for tx in raw_transactions:
+    for tx_id in raw_transactions:
+        tx = raw_transactions[tx_id]
         for vin in tx['vin']:
             if 'txinwitness' in vin:
                 if len(vin['txinwitness']) >= 2:


### PR DESCRIPTION
Fix https://github.com/CounterpartyXCP/counterparty-lib/issues/1100

```
pubkeyhash: mi6fCpyaPBN39ixyYbXdjEMqPntV89RMJc

raw_transactions: {
'eda58dae634fd81e0647a4a85785e1ae6edd06d127ad333165639f70d2924e0b': {'vout': [{'value': 0.0, 'scriptPubKey': {'type': 'nulldata', 'hex': '6a2ed9daf1e7efa7afa25e14d54b0c0f9ea4fda6d5494293b9f4d5009ce57ce5ecd4064664a4bc06844ad697854831cf', 'asm': 'OP_RETURN d9daf1e7efa7afa25e14d54b0c0f9ea4fda6d5494293b9f4d5009ce57ce5ecd4064664a4bc06844ad697854831cf'}, 'n': 0}, {'value': 0.97732863, 'scriptPubKey': {'type': 'pubkeyhash', 'addresses': ['mi6fCpyaPBN39ixyYbXdjEMqPntV89RMJc'], 'hex': '76a9141c5020cf9c04fdd8229dcced2e8e026b62b83f1d88ac', 'asm': 'OP_DUP OP_HASH160 1c5020cf9c04fdd8229dcced2e8e026b62b83f1d OP_EQUALVERIFY OP_CHECKSIG', 'reqSigs': 1}, 'n': 1}], 'vin': [{'vout': 1, 'scriptSig': {'hex': '47304402200be4c33845a44f56b4f19304b66963493bc9d00545e07694b19ec2dbe4f73da5022046a3ca7da63f2379d432d481a0c353f6f94d31ca07804b87120b6b30a4cfbb9301210346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9', 'asm': '304402200be4c33845a44f56b4f19304b66963493bc9d00545e07694b19ec2dbe4f73da5022046a3ca7da63f2379d432d481a0c353f6f94d31ca07804b87120b6b30a4cfbb93[ALL] 0346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9'}, 'txid': 'f86c1e410f6ec7a013251277839b2804d7c52385bfd58d5bee214051ab15236a', 'sequence': 4294967295}], 'txid': 'eda58dae634fd81e0647a4a85785e1ae6edd06d127ad333165639f70d2924e0b', 'weight': 992, 'hex': '01000000016a2315ab514021ee5b8dd5bf8523c5d704289b8377122513a0c76e0f411e6cf8010000006a47304402200be4c33845a44f56b4f19304b66963493bc9d00545e07694b19ec2dbe4f73da5022046a3ca7da63f2379d432d481a0c353f6f94d31ca07804b87120b6b30a4cfbb9301210346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9ffffffff020000000000000000306a2ed9daf1e7efa7afa25e14d54b0c0f9ea4fda6d5494293b9f4d5009ce57ce5ecd4064664a4bc06844ad697854831cfff48d305000000001976a9141c5020cf9c04fdd8229dcced2e8e026b62b83f1d88ac00000000', 'version': 1, 'hash': 'eda58dae634fd81e0647a4a85785e1ae6edd06d127ad333165639f70d2924e0b', 'vsize': 248, 'blocktime': 1585628298, 'size': 248, 'time': 1585628298, 'locktime': 0, 'blockhash': '00000000000004a0fa44951cc5c720d71c6d989f898db929df743fc0a211eeb9', 'confirmations': 210139}, '193183501906e7274d057729e0d570df4a2f5747753a1e02a1302db7f343145a': {'vout': [{'value': 0.0, 'scriptPubKey': {'type': 'nulldata', 'hex': '6a2e0bcefc223d163382ef40e3b075feccc6b47b5307f822c6b107c5ebbafd777d326335edeecc05aa3d90d77e51e8dd', 'asm': 'OP_RETURN 0bcefc223d163382ef40e3b075feccc6b47b5307f822c6b107c5ebbafd777d326335edeecc05aa3d90d77e51e8dd'}, 'n': 0}, {'value': 0.11991402, 'scriptPubKey': {'type': 'pubkeyhash', 'addresses': ['mi6fCpyaPBN39ixyYbXdjEMqPntV89RMJc'], 'hex': '76a9141c5020cf9c04fdd8229dcced2e8e026b62b83f1d88ac', 'asm': 'OP_DUP OP_HASH160 1c5020cf9c04fdd8229dcced2e8e026b62b83f1d OP_EQUALVERIFY OP_CHECKSIG', 'reqSigs': 1}, 'n': 1}], 'vin': [{'vout': 1, 'scriptSig': {'hex': '47304402203d1194d1345abcc01aa8ecc8e5dc73b1d49d21c73359f95c6edb8be5fdea1a2302205f622ed94795a8ac9a2d0dcb0707bd41be9ca98c60455ee23a62b01e4bd4cf0c01210346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9', 'asm': '304402203d1194d1345abcc01aa8ecc8e5dc73b1d49d21c73359f95c6edb8be5fdea1a2302205f622ed94795a8ac9a2d0dcb0707bd41be9ca98c60455ee23a62b01e4bd4cf0c[ALL] 0346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9'}, 'txid': 'c00b12eb0a7adeae9eb49a7e1b00a1a3bac5da0c9dee0fba5fdf1d465874dfb3', 'sequence': 4294967295}], 'txid': '193183501906e7274d057729e0d570df4a2f5747753a1e02a1302db7f343145a', 'weight': 992, 'hex': '0100000001b3df7458461ddf5fba0fee9d0cdac5baa3a1001b7e9ab49eaede7a0aeb120bc0010000006a47304402203d1194d1345abcc01aa8ecc8e5dc73b1d49d21c73359f95c6edb8be5fdea1a2302205f622ed94795a8ac9a2d0dcb0707bd41be9ca98c60455ee23a62b01e4bd4cf0c01210346f73bedbf53b75b149d58cad16a3257163eb4022c8e0a3d366db2bfcc369dc9ffffffff020000000000000000306a2e0bcefc223d163382ef40e3b075feccc6b47b5307f822c6b107c5ebbafd777d326335edeecc05aa3d90d77e51e8dd6af9b600000000001976a9141c5020cf9c04fdd8229dcced2e8e026b62b83f1d88ac00000000', 'version': 1, 'hash': '193183501906e7274d057729e0d570df4a2f5747753a1e02a1302db7f343145a', 'vsize': 248, 'blocktime': 1547723434, 'size': 248, 'time': 1547723434, 'locktime': 0, 'blockhash': '00000000000774c0aac48dda4e54968eb89d5228a368581f0a2743f1093e2e1b', 'confirmations': 449827}
```
`raw_transactions` is a hash map `{ key1: {/*tx info*/}, key2: {/*tx info*/} }` with key1, key2 are String therefore we can't `key1['vin']`