### PR TITLE
Store memos in "MPMA send" as BLOB.

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -306,7 +306,7 @@ def adjust_get_sends_results(query_result):
                 send_row['memo'] = None
             else:
                 send_row['memo_hex'] = binascii.hexlify(send_row['memo']).decode('utf8')
-                send_row['memo'] = send_row['memo'].decode('utf-8')
+                send_row['memo'] = send_row['memo'].decode('utf-8', 'replace')
         except UnicodeDecodeError:
             send_row['memo'] = ''
         filtered_results.append(send_row)

--- a/counterpartylib/lib/messages/versions/mpma_util/internals.py
+++ b/counterpartylib/lib/messages/versions/mpma_util/internals.py
@@ -211,10 +211,6 @@ def _decode_memo(stream):
         mlen = stream.read('uint:6')
         data = stream.read('bytes:%i' % mlen)
 
-        if not(is_hex):
-            # is an utf8 string
-            data = data.decode('utf-8')
-
         return data, is_hex
     else:
         return None, None


### PR DESCRIPTION
This patch is based on Monaparty#25.
It should be worked on Counterparty but I've tested on Monaparty only.
Please be careful before applying this PR.

The `memo` field in the `sends` table should be BLOB (`bytes`).
But the MPMA decoder sets as `str`.
So a type mismatch error will be occurred in `api.py` when a user call `get_sends` API.

As the type of `memo` is BLOB, decoding `memo` to UTF-8 may be failed.
It's better to decode with `replace`, IMO.