### PR TITLE
Use `STATUS_OPEN` instead of `dispenser_status`.

### DIFF
--- a/counterpartylib/lib/messages/dispenser.py
+++ b/counterpartylib/lib/messages/dispenser.py
@@ -213,9 +213,8 @@ def parse (db, tx, message):
                 bindings = {
                     'source': tx['source'],
                     'asset': asset,
-                    'status': dispenser_status,
-                    'give_remaining': existing[0]['give_remaining'] + escrow_quantity,
                     'status': STATUS_OPEN,
+                    'give_remaining': existing[0]['give_remaining'] + escrow_quantity,
                     'block_index': tx['block_index']
                 }
                 try:


### PR DESCRIPTION
Since `STATUS_OPEN_EMPTY_ADDRESS` was added.
It can be closed dispensers that have `STATUS_OPEN` as their status.

This patch may be required protocol changes.