### PR TITLE
- Remove "FROM counterparty/base" to upgrade to Ubuntu 18.04 in order…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,24 @@
-FROM counterparty/base
+FROM ubuntu:18.04
 
-MAINTAINER Counterparty Developers <dev@counterparty.io>
+#MAINTAINER Counterparty Developers <dev@counterparty.io>
+
+# Install common dependencies
+RUN apt-get update && apt-get install -y apt-utils ca-certificates wget curl git mercurial \
+    python3 python3-dev python3-pip python3-setuptools python3-appdirs \
+    build-essential vim unzip software-properties-common sudo gettext-base \
+    net-tools iputils-ping telnet lynx locales
+
+# Upgrade pip3 to newest
+RUN pip3 install --upgrade pip
+
+# Set locale
+RUN dpkg-reconfigure -f noninteractive locales && \
+    locale-gen en_US.UTF-8 && \
+    /usr/sbin/update-locale LANG=en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# Set home dir env variable
+ENV HOME /root
 
 # Install counterparty-lib
 COPY . /counterparty-lib


### PR DESCRIPTION
… to install the required version of setuptools-markdown