### PR TITLE
Removed forbidden words check for bindings

### DIFF
--- a/counterpartylib/lib/api.py
+++ b/counterpartylib/lib/api.py
@@ -123,7 +123,7 @@ def db_query(db, statement, bindings=(), callback=None, **callback_args):
     # Sanitize.
     forbidden_words = ['pragma', 'attach', 'database', 'begin', 'transaction']
     for word in forbidden_words:
-        if word in statement.lower() or any([word in str(binding).lower() for binding in bindings]):
+        if word in statement.lower(): # or any([word in str(binding).lower() for binding in bindings]):
             raise APIError("Forbidden word in query: '{}'.".format(word))
 
     if hasattr(callback, '__call__'):


### PR DESCRIPTION
There is a check for forbidden words like 'begin', 'pragma' in the db_query function in api module. In the statement of the query it's correct to prevent them, but the bindings are well escaped using the function cursor.execute(statement, bindings), so there is no need to forbid any words in there