### PR TITLE
adjust multisig encoding dust back to default 7800 sats

### DIFF
--- a/counterpartylib/lib/config.py
+++ b/counterpartylib/lib/config.py
@@ -99,7 +99,7 @@ BURN_END_REGTEST_TESTCOIN = 150
 # Protocol defaults
 # NOTE: If the DUST_SIZE constants are changed, they MUST also be changed in counterblockd/lib/config.py as well
 DEFAULT_REGULAR_DUST_SIZE = 546          # TODO: Revisit when dust size is adjusted in bitcoin core
-DEFAULT_MULTISIG_DUST_SIZE = 546         # <https://bitcointalk.org/index.php?topic=528023.msg7469941#msg7469941>
+DEFAULT_MULTISIG_DUST_SIZE = 7800        # <https://bitcointalk.org/index.php?topic=528023.msg7469941#msg7469941>
 DEFAULT_OP_RETURN_VALUE = 0
 DEFAULT_FEE_PER_KB_ESTIMATE_SMART = 1024
 DEFAULT_FEE_PER_KB = 25000               # sane/low default, also used as minimum when estimated fee is used


### PR DESCRIPTION
Users are reporting issues with broadcasting transactions using the new 546 sats DUST limit. 

Adjusting multisig DUST back to 7800 sats