### PR TITLE
migrate CircleCI config to v2 to get automated CI tests running again

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,29 +1,106 @@
-# Keep this as non-docker for now, to give some variety to our test configurations, as travis builds with docker
-dependencies:
-    override:
-        - rm -rf /home/ubuntu/virtualenvs/venv-*/lib/python3.4/site-packages/apsw*
-        - pip install --upgrade pip
-        - pip install -r requirements.txt
-        - python setup.py install
-        - python -c "import apsw; print(apsw.apswversion())"
-test:
-    override:
-        - py.test --verbose --capture=no counterpartylib/test/config_context_test.py
-        - py.test --verbose --capture=no counterpartylib/test/unit_test.py
-        - py.test --verbose --capture=no counterpartylib/test/utxolocks_test.py
-        - py.test --verbose --capture=no counterpartylib/test/bytespersigop_test.py
-        - py.test --verbose --capture=no counterpartylib/test/parse_block_test.py
-        - py.test --verbose --capture=no --skiptestbook=all counterpartylib/test/integration_test.py
-        - py.test --verbose --capture=no --skiptestbook=mainnet -k test_book counterpartylib/test/reparse_test.py
-        - py.test --verbose --capture=no --skiptestbook=testnet -k test_book counterpartylib/test/reparse_test.py:
-            timeout: 5400
-        - py.test --verbose --capture=no counterpartylib/test/database_version_test.py
-machine:
-    pre:
-        - mkdir -p ~/.local/share/counterparty;
-        - wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db-testnet-7.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz;
-        - tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz;
-        - wget https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db.latest.tar.gz;
-        - tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db.latest.tar.gz;
-    python:
-        version: 3.4.1
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+orbs:
+  python: circleci/python@2.0.3
+
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.6.15
+
+    steps:
+      - checkout
+
+      - python/install-packages:
+          pkg-manager: pip
+
+      - run:
+          name: Run counterparty-lib setup and install
+          command: python setup.py develop 
+
+      - run: 
+          name: Run apsw setup and install
+          command: python setup.py install_apsw
+
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - .      
+
+  test:
+    docker:
+      - image: cimg/python:3.6.15
+
+    steps:
+      - attach_workspace:
+          at: ~/
+      
+      - run:
+          name: "Run tests"
+          command: |
+            mkdir test-results
+            py.test --junitxml=test-results/junit.xml --verbose --skiptestbook=all --cov-config=.coveragerc --cov-report=term-missing --cov=./ counterpartylib
+
+      - store_test_results:
+          path: test-results
+
+  test-reparse-testnet:
+    docker:
+        - image: cimg/python:3.6.15
+    
+    steps:
+      - attach_workspace:
+          at: ~/
+
+      - run:
+          name: "Get latest testnet db file"
+          command: |
+            mkdir -p ~/.local/share/counterparty
+            wget https://counterparty.io/bootstrap/counterparty-db-testnet-7.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz
+            tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db-testnet.latest.tar.gz
+
+      - run:
+          name: "Run testnet reparse test"
+          command: |
+            mkdir test-results
+            py.test --junitxml=test-results/junit.xml --verbose --capture=no --skiptestbook=mainnet -k test_book counterpartylib/test/reparse_test.py
+      
+      - store_test_results:
+          path: test-results
+
+  test-reparse-mainnet:
+    docker:
+        - image: cimg/python:3.6.15
+    
+    steps:
+      - attach_workspace:
+          at: ~/
+
+      - run:
+          name: "Get latest mainnet db file"
+          command: |
+            mkdir -p ~/.local/share/counterparty
+            wget https://counterparty.io/bootstrap/counterparty-db.latest.tar.gz -O ~/.local/share/counterparty/counterparty-db.latest.tar.gz
+            tar -C ~/.local/share/counterparty -xvzf ~/.local/share/counterparty/counterparty-db.latest.tar.gz
+
+      - run:
+          name: "Run testnet reparse test"
+          command: |
+            mkdir test-results
+            py.test --junitxml=test-results/junit.xml --verbose --capture=no --skiptestbook=testnet -k test_book counterpartylib/test/reparse_test.py
+      
+      - store_test_results:
+          path: test-results
+
+
+workflows:
+  build-and-test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - test-reparse-testnet:
+          requires:
+            - build


### PR DESCRIPTION
I've been looking at doing some work on counterparty and as a first step have been looking at getting all of the tests running. I noticed that we have a few tests which are failing on master, and also that the automated Circle CI tests on PR's [are failing](https://app.circleci.com/pipelines/github/CounterpartyXCP/counterparty-lib/139/workflows/53cdb713-8230-47cc-8815-8f6ff6d17de7/jobs/1944) with errors like:
```
# ERROR IN CONFIG FILE:
# [#] required key [jobs] not found
```

It looks like we are using a very old version of the CircleCI YAML config which is no longer supported, so PR migrates the config to v2 of the CircleCI YAML.

Here is an example of what the running tests look like with this config using my fork of `counterparty-lib`: https://app.circleci.com/pipelines/github/windsok/counterparty-lib/20/workflows/799392c7-437b-490d-ae59-09797324f6e2

This PR is a first step to get the Automated tests running again, and then I'll take a look into what changes are required to get all tests passing again.

I'm not sure if we will need any config on the CircleCI side to go along with these changes, but I guess we can tackle that when it comes. Let me know what you think.
