### PR TITLE
Fix ARC4 tests to use static dust size

### DIFF
--- a/counterpartylib/test/arc4_test.py
+++ b/counterpartylib/test/arc4_test.py
@@ -122,7 +122,7 @@ def test_transaction_arc4_mocked(server_db):
     """
     v = int(100 * 1e8)
     tx_info = send.compose(server_db, ADDR[0], ADDR[1], 'XCP', v)
-    send1hex = transaction.construct(server_db, tx_info)
+    send1hex = transaction.construct(db=server_db, tx_info=tx_info, regular_dust_size=5430)
 
     assert send1hex == '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff0336150000000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000000000001e6a1c8a5dda15fb6f05628a061e67576e926dc71a7fa2f0cceb951120a9322f30ea0b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'
 
@@ -137,6 +137,6 @@ def test_transaction_arc4_unmocked(server_db):
     with util_test.ConfigContext(DISABLE_ARC4_MOCKING=True):
         v = int(100 * 1e8)
         tx_info = send.compose(server_db, ADDR[0], ADDR[1], 'XCP', v)
-        send1hex = transaction.construct(server_db, tx_info)
+        send1hex = transaction.construct(db=server_db, tx_info=tx_info, regular_dust_size=5430)
 
         assert send1hex == '0100000001c1d8c075936c3495f6d653c50f73d987f75448d97a750249b1eb83bee71b24ae000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788acffffffff0336150000000000001976a9148d6ae8a3b381663118b4e1eff4cfc7d0954dd6ec88ac00000000000000001e6a1c2a504df746f83442653dd7ada4dc727a030865749e9fba58ba71d71a2f30ea0b000000001976a9144838d8b3588c4c7ba7c1d06f866e9b3739c6303788ac00000000'


### PR DESCRIPTION
It looks like when these ARC4 tests were written, they made the assumption that the default dust size set in `config.py` would always stay the same. Since this value was modified the tests break as the transaction hex returned contains a different output value.

Since these tests are not intended to test any part of the dust / output value logic, it seems safe to just pass a static known dust size here, which corresponds to what the output value in the expected hex is.