### PR TITLE
Update test scenario db dumps to fix expected sqlite default page_size

### DIFF
--- a/counterpartylib/test/fixtures/scenarios/multisig_1_of_2.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_1_of_2.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_1_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_1_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_2_of_2.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_2_of_2.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_2_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_2_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_3_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_3_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/parseblock_unittest_fixture.sql
+++ b/counterpartylib/test/fixtures/scenarios/parseblock_unittest_fixture.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/simplesig.sql
+++ b/counterpartylib/test/fixtures/scenarios/simplesig.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/unittest_fixture.sql
+++ b/counterpartylib/test/fixtures/scenarios/unittest_fixture.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=1024;
+-- PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;


### PR DESCRIPTION
In some of the integration tests we run through a scenario then dump the database from sqlite to compare what was created there to a known expected output.

Back in 2016 the default `page_size` for sqlite was updated from `1024` to `4096` - https://www.sqlite.org/pgszchng2016.html

This is being included in the checks, and some tests are failing due to our expected output's having the old `1024` value, instead of `4096`.

A better fix might be to modify the test logic to not compare on these values, but since this value is unlikely to change again anytime soon, seems OK for now to just update the expected value to `4096`
