### PR TITLE
fix integration_test.py

### DIFF
--- a/counterpartylib/test/fixtures/scenarios/multisig_1_of_2.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_1_of_2.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_1_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_1_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_2_of_2.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_2_of_2.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_2_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_2_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/multisig_3_of_3.sql
+++ b/counterpartylib/test/fixtures/scenarios/multisig_3_of_3.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/parseblock_unittest_fixture.sql
+++ b/counterpartylib/test/fixtures/scenarios/parseblock_unittest_fixture.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/simplesig.sql
+++ b/counterpartylib/test/fixtures/scenarios/simplesig.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/fixtures/scenarios/unittest_fixture.sql
+++ b/counterpartylib/test/fixtures/scenarios/unittest_fixture.sql
@@ -1,4 +1,4 @@
--- PRAGMA page_size=4096;
+PRAGMA page_size=4096;
 -- PRAGMA encoding='UTF-8';
 -- PRAGMA auto_vacuum=NONE;
 -- PRAGMA max_page_count=1073741823;

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -483,7 +483,7 @@ def run_scenario(scenario):
             with MockProtocolChangesContext(**(mock_protocol_changes or {})):
                 module = sys.modules['counterpartylib.lib.messages.{}'.format(tx[0])]
                 compose = getattr(module, 'compose')
-                unsigned_tx_hex = transaction.construct(db, compose(db, *tx[1]), **tx[2])
+                unsigned_tx_hex = transaction.construct(db=db, tx_info=compose(db, *tx[1]), regular_dust_size=5430, **tx[2])
                 raw_transactions.append({tx[0]: unsigned_tx_hex})
                 insert_raw_transaction(unsigned_tx_hex, db)
         else:


### PR DESCRIPTION
fixes `integration_test.py` which had two issues:

* All integration test scenarios were set up with the assumption that generation raw transactions would be using a `regular_dust_size` of `5430`. Explicitly pass this value, similar to https://github.com/CounterpartyXCP/counterparty-lib/pull/1177

* Generated database dumps after scenario runs now have the `PRAGMA page_size` command uncommented. Unknown why this changed, likely a change in default sqllite behavior at some point. 