### PR TITLE
Fix address pack unit tests

### DIFF
--- a/counterpartylib/test/conftest.py
+++ b/counterpartylib/test/conftest.py
@@ -109,7 +109,7 @@ def pytest_generate_tests(metafunc):
     """Generate all py.test cases. Checks for different types of tests and creates proper context."""
     if metafunc.function.__name__ == 'test_vector':
         args = util_test.vector_to_args(UNITTEST_VECTOR, pytest.config.option.function)
-        metafunc.parametrize('tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes', args)
+        metafunc.parametrize('tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, config_context', args)
     elif metafunc.function.__name__ == 'test_scenario':
         args = []
         for scenario_name in INTEGRATION_SCENARIOS:

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -4557,24 +4557,28 @@ UNITTEST_VECTOR = {
     },
     'address': {
         'pack': [{
+            'config_context': {'ADDRESSVERSION': config.ADDRESSVERSION_MAINNET},
             'in': ('1AAAA1111xxxxxxxxxxxxxxxxxxy43CZ9j',),
             'out': bytes.fromhex('006474849fc9ac0f5bd6b49fe144d14db7d32e2445')
         },
         {
+            'config_context': {'ADDRESSVERSION': config.ADDRESSVERSION_MAINNET},
             'in': ('1AAAA2222xxxxxxxxxxxxxxxxxxy4pQ3tU',),
             'out': bytes.fromhex('00647484b055e2101927e50aba74957ba134d501d7')
         },
         {
+            'config_context': {'P2SH_ADDRESSVERSION': config.P2SH_ADDRESSVERSION_MAINNET},
             'in': ('3AAAA1111xxxxxxxxxxxxxxxxxxy3SsDsZ',),
             'out': bytes.fromhex('055ce31be63403fa7b19f2614272547c15c8df86b9')
         },
         {
+            'config_context': {'P2SH_ADDRESSVERSION': config.P2SH_ADDRESSVERSION_TESTNET},
             'in': ('2MtAV7xpAzU69E8GxRF2Vd2xt79kDnif6F5',),
             'out': bytes.fromhex('C40A12AD889AECC8F6213BFD6BD47911CAB1C30E5F')
         },
         {
             'in': ('BADBASE58III',),
-            'error': (bitcoinlib.base58.InvalidBase58Error, "Character 'I' is not a valid base58 character")
+            'error': (script.Base58Error, "Not a valid Base58 character: ‘I’")
         }],
         'unpack': [{
             'in': (bytes.fromhex('006474849fc9ac0f5bd6b49fe144d14db7d32e2445'),),

--- a/counterpartylib/test/unit_test.py
+++ b/counterpartylib/test/unit_test.py
@@ -4,17 +4,20 @@ import pytest
 from counterpartylib.test import conftest  # this is require near the top to do setup of the test suite
 from counterpartylib.test import util_test
 from counterpartylib.test.util_test import CURR_DIR
+from counterpartylib.lib import config
 
 FIXTURE_SQL_FILE = CURR_DIR + '/fixtures/scenarios/unittest_fixture.sql'
 FIXTURE_DB = tempfile.gettempdir() + '/fixtures.unittest_fixture.db'
 
 @conftest.add_fn_property(DISABLE_ARC4_MOCKING=True)
 @pytest.mark.usefixtures("api_server")
-def test_vector(tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, server_db):
+def test_vector(tx_name, method, inputs, outputs, error, records, comment, mock_protocol_changes, config_context, server_db):
     """Test the outputs of unit test vector. If testing parse, execute the transaction data on test db."""
 
     # disable arc4 mocking for vectors because we're too lazy to update all the vectors
-    with util_test.ConfigContext(DISABLE_ARC4_MOCKING=True):
+    config_context.update({'DISABLE_ARC4_MOCKING': True})
+
+    with util_test.ConfigContext(**config_context):
         # force unit tests to always run against latest protocol changes
         from counterpartylib.test import conftest
         conftest.ALWAYS_LATEST_PROTOCOL_CHANGES = True

--- a/counterpartylib/test/util_test.py
+++ b/counterpartylib/test/util_test.py
@@ -581,8 +581,9 @@ def vector_to_args(vector, functions=[]):
                 records = params.get('records', None)
                 comment = params.get('comment', None)
                 mock_protocol_changes = params.get('mock_protocol_changes', None)
+                config_context = params.get('config_context', {})
                 if functions == [] or (tx_name + '.' + method) in functions:
-                    args.append((tx_name, method, params['in'], outputs, error, records, comment, mock_protocol_changes))
+                    args.append((tx_name, method, params['in'], outputs, error, records, comment, mock_protocol_changes, config_context))
     return args
 
 def exec_tested_method(tx_name, method, tested_method, inputs, server_db):


### PR DESCRIPTION
In https://github.com/CounterpartyXCP/counterparty-lib/pull/1164/ an additional check was added to the address `pack` function to validate that an address is actually a valid address. This change caused the unit tests on this function to break as the `validate` function [passes in](https://github.com/CounterpartyXCP/counterparty-lib/blob/158496b30b3cc65b108f92c942fdda993d84e01b/counterpartylib/lib/script.py#L50) the `ADDRESSVERSION` which is dynamically configured depending on if we are running on mainnet or tesnet.

Some of the unit tests are testing mainnet addresses, and some are testing testnet addresses, so we need to set this context in the unit test itself to ensure that the `validate` function will run with the correct `ADDRESSVERSION`.

This PR makes the following changes:
* Introduces the ability to set an optional `config_context` on each unit test vector which will override any default config context settings for that specific test vector
* Updates the failing tests to set the correct config context
* Updates the `BADBASE58III` error case test with the new expected error, as this test case now fails in the `validate` function, instead of the `pack` function where it failed previously.