### PR TITLE
- NO_BOOTSTRAP option and selective bootstrap downloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ WORKDIR /
 EXPOSE 4000 14000
 
 # NOTE: Defaults to running on mainnet, specify -e TESTNET=1 to start up on testnet
-ENTRYPOINT ["start.sh"]
+ENTRYPOINT start.sh ${BTC_NETWORK} ${NO_BOOTSTRAP}

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -10,15 +10,17 @@ fi
 
 # Bootstrap if the database does not exist (do this here to handle cases
 # where a volume is mounted over the share dir, like the fednode docker compose config does...)
-if [ ! -f /root/.local/share/counterparty/counterparty.db ]; then
-    echo "Downloading mainnet bootstrap DB..."
-    counterparty-server bootstrap --quiet
-	PARAMS='--checkdb'
-fi
-if [ ! -f /root/.local/share/counterparty/counterparty.testnet.db ]; then
-    echo "Downloading testnet bootstrap DB..."
-    counterparty-server --testnet bootstrap --quiet
-	PARAMS='--checkdb'
+if ([ -z "$2" ] || [ $2 != "true" ]); then
+    if [ ! -f /root/.local/share/counterparty/counterparty.db ] && [ $1 = "mainnet" ]; then
+        echo "Downloading mainnet bootstrap DB..."
+        counterparty-server bootstrap --quiet
+        PARAMS="${PARAMS} --checkdb"
+    fi
+    if [ ! -f /root/.local/share/counterparty/counterparty.testnet.db ] && [ $1 = "testnet" ]; then
+        echo "Downloading testnet bootstrap DB..."
+        counterparty-server --testnet bootstrap --quiet
+        PARAMS="${PARAMS} --checkdb"
+    fi
 fi
 
 # Kick off the server, defaulting to the "start" subcommand


### PR DESCRIPTION
- Passing a new parameter NO_BOOTSTRAP to disable bootstrap downloading and start parsing from scratch

- Passing a new parameter BTC_NETWORK to make mainnet container only download the mainnet bootstrap, the same with testnet