### PR TITLE
v9.61.0 Release Candidate

### DIFF
--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -417,42 +417,42 @@
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2412394
   },
   "issuance_backwards_compatibility": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2422000
   },
   "zero_balance_ownership_sweep_fix": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2505725
   },
   "dispenser_origin_permission_extended": {
       "minimum_version_major": 9,
       "minimum_version_minor": 59,
       "minimum_version_revision": 6,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2499850
   },
   "multiple_dispenses": {
       "minimum_version_major": 9,
       "minimum_version_minor": 59,
       "minimum_version_revision": 6,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2420996
   },
   "issuance_description_special_null": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 819300,
+      "block_index": 850000,
       "testnet_block_index": 2505725
   },
   "addrindexrs_required_version": {
@@ -460,7 +460,7 @@
       "1":{
         "value":"0.4.0"
       },
-      "819300":{
+      "850000":{
         "value":"0.4.1"
       }   
     },
@@ -478,7 +478,7 @@
       "1":{
         "value":0  
       },
-      "819300":{
+      "850000":{
         "value":1000
       }   
     },
@@ -496,7 +496,7 @@
       "1":{
         "value":0
       },
-      "819300":{
+      "850000":{
         "value":5
       }   
     },
@@ -514,7 +514,7 @@
       "1":{
         "value":0  
       },
-      "819300":{
+      "850000":{
         "value":5
       }   
     },
@@ -532,7 +532,7 @@
       "1":{
         "value":0  
       },
-      "819300":{
+      "825000":{
         "value":0.001
       }   
     },

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -417,7 +417,7 @@
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 999999,
+      "block_index": 819300,
       "testnet_block_index": 2412394
   },
   "issuance_backwards_compatibility": {
@@ -431,7 +431,7 @@
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 999999,
+      "block_index": 819300,
       "testnet_block_index": 2505725
   },
   "dispenser_origin_permission_extended": {

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -417,42 +417,42 @@
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2412394
   },
   "issuance_backwards_compatibility": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2422000
   },
   "zero_balance_ownership_sweep_fix": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2505725
   },
   "dispenser_origin_permission_extended": {
       "minimum_version_major": 9,
       "minimum_version_minor": 59,
       "minimum_version_revision": 6,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2499850
   },
   "multiple_dispenses": {
       "minimum_version_major": 9,
       "minimum_version_minor": 59,
       "minimum_version_revision": 6,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2420996
   },
   "issuance_description_special_null": {
       "minimum_version_major": 9,
       "minimum_version_minor": 60,
       "minimum_version_revision": 2,
-      "block_index": 850000,
+      "block_index": 999999,
       "testnet_block_index": 2505725
   },
   "addrindexrs_required_version": {
@@ -460,7 +460,7 @@
       "1":{
         "value":"0.4.0"
       },
-      "850000":{
+      "999999":{
         "value":"0.4.1"
       }   
     },
@@ -478,7 +478,7 @@
       "1":{
         "value":0  
       },
-      "850000":{
+      "999999":{
         "value":1000
       }   
     },
@@ -496,7 +496,7 @@
       "1":{
         "value":0
       },
-      "850000":{
+      "999999":{
         "value":5
       }   
     },
@@ -514,7 +514,7 @@
       "1":{
         "value":0  
       },
-      "850000":{
+      "999999":{
         "value":5
       }   
     },
@@ -532,7 +532,7 @@
       "1":{
         "value":0  
       },
-      "825000":{
+      "999999":{
         "value":0.001
       }   
     },


### PR DESCRIPTION
CIP-Discussion: https://github.com/CounterpartyXCP/cips/discussions/124

An almost identical representation of work up to commit https://github.com/CounterpartyXCP/counterparty-lib/commit/fffdb01e966f43979e7f853f7bff224c663f0378. @jdogresorg Thanks for this work (and the [summary](https://github.com/CounterpartyXCP/counterparty-lib/commit/91c744e59fea3298ce265ea893ef738f04f5d714) with links!).

The only change in this PR focuses on one part of the [main issue](https://github.com/CounterpartyXCP/counterparty-lib/issues/1275) that needs URGENT action:

***CURRENT fednode installers will activate the changes at the VERY SOON block height. This is a BIG ISSUE, effectively ALREADY acting like a forced sudden protocol update!***

This PR handles part of the problem by setting the activation block way into the future as a placeholder. But what is left is not possible for me to change without repository contributor privileges, which is a simple rename of the current `master` branch. (And now, it should also include removal of the non-consensus [published release](https://github.com/CounterpartyXCP/counterparty-lib/releases/tag/v9.61.0).)