### PR TITLE
hotfix - invalid `null` description on first issuance

### DIFF
--- a/counterpartylib/lib/messages/issuance.py
+++ b/counterpartylib/lib/messages/issuance.py
@@ -508,7 +508,10 @@ def parse (db, tx, message, message_type_id):
                     asset = namedAsset
             
             if description == None:
-                description = util.get_asset_description(db, asset)
+                try:
+                    description = util.get_asset_description(db, asset)
+                except exceptions.AssetError:
+                    description = ""
             
             status = 'valid'
         except exceptions.AssetIDError:


### PR DESCRIPTION
- Fixed invalid description null on the first issuance