### PR TITLE
Correct `block_index` Used for Dispensers Closing Delay

### DIFF
--- a/counterpartylib/lib/messages/dispenser.py
+++ b/counterpartylib/lib/messages/dispenser.py
@@ -596,7 +596,7 @@ def close_pending(db, block_index):
                 'source': dispenser['tx_source'],
                 'asset': dispenser['asset'],
                 'status': STATUS_CLOSED,
-                'block_index': dispenser['tx_block_index'],
+                'block_index': block_index,
                 'tx_index': dispenser['tx_index']
             }
             sql = 'UPDATE dispensers SET give_remaining=0, status=:status WHERE source=:source AND asset=:asset'


### PR DESCRIPTION
THIS FIX IS FOR REFERENCE ONLY!

This fixs the wrong block_index used when closing a dispenser with delay. With this fix there is no need to use the recent counterparty and counterblock PRs to fix the non-correlated block_index but a full parse from the last update block_index is needed and that will change the message ledger (but it won't change any credit/debit nor transactions).

This fix could be apply from a specify block_index but a protocol change is needed and those non-correlated block_index will remain in the message table and the fixes for counterparty and counterblock would be needed.