### PR TITLE
Add 0.10 XCP fee on numerics

### DIFF
--- a/counterpartylib/lib/messages/issuance.py
+++ b/counterpartylib/lib/messages/issuance.py
@@ -245,7 +245,10 @@ def validate (db, source, destination, asset, quantity, divisible, lock, reset, 
                     # subasset issuance is 0.25
                     fee = int(0.25 * config.UNIT)
                 elif len(asset) >= 13:
-                    fee = 0
+                    if util.enabled('numeric_asset_fee'):
+                        fee = int(0.10 * config.UNIT)
+                    else:
+                        fee = 0
                 else:
                     fee = int(0.5 * config.UNIT)
             elif block_index >= 291700 or config.TESTNET or config.REGTEST:     # Protocol change.

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -459,7 +459,7 @@
       "minimum_version_major": 9,
       "minimum_version_minor": 61,
       "minimum_version_revision": 1,
-      "block_index": 829020,
+      "block_index": 824888,
       "testnet_block_index": 2571199
   },
   "addrindexrs_required_version": {

--- a/counterpartylib/protocol_changes.json
+++ b/counterpartylib/protocol_changes.json
@@ -455,6 +455,13 @@
       "block_index": 819300,
       "testnet_block_index": 2505725
   },
+  "numeric_asset_fee": {
+      "minimum_version_major": 9,
+      "minimum_version_minor": 61,
+      "minimum_version_revision": 1,
+      "block_index": 829020,
+      "testnet_block_index": 2571199
+  },
   "addrindexrs_required_version": {
     "mainnet":{
       "1":{


### PR DESCRIPTION
This pull request puts a 0.10 XCP fee on numeric assets and activates on block 829,020.

# Activation Logic
```
 144 blocks/day
x 30 days (1 month)
---
4,320 blocks

824,700 current block
+ 4,320 blocks
---
829,020 = Activation Block (1 month)
```