### PR TITLE
Dividend fix

### DIFF
--- a/counterpartylib/lib/messages/dividend.py
+++ b/counterpartylib/lib/messages/dividend.py
@@ -162,6 +162,8 @@ def compose (db, source, quantity_per_unit, asset, dividend_asset):
 def parse (db, tx, message):
     dividend_parse_cursor = db.cursor()
 
+    fee = 0
+
     # Unpack message.
     try:
         if (tx['block_index'] > 288150 or config.TESTNET or config.REGTEST) and len(message) == LENGTH_2:


### PR DESCRIPTION
Got this error when parsing `testnet`:

```
Traceback (most recent call last):
  File "/home/tower/counterparty/counterparty-lib/counterpartylib/lib/blocks.py", line 115, in parse_tx
    dividend.parse(db, tx, message)
  File "/home/tower/counterparty/counterparty-lib/counterpartylib/lib/messages/dividend.py", line 217, in parse
    'fee_paid': fee,
                ^^^
UnboundLocalError: cannot access local variable 'fee' where it is not associated with a value
```