### PR TITLE
Kill `addrindexrs`

### DIFF
--- a/counterpartylib/lib/backend/addrindexrs.py
+++ b/counterpartylib/lib/backend/addrindexrs.py
@@ -222,8 +222,8 @@ def getrawtransaction_batch(txhash_list, verbose=False, skip_missing=False, _ret
     for tx_hash in txhash_list.difference(noncached_txhashes):
         raw_transactions_cache.refresh(tx_hash)
 
-    _logger.debug("getrawtransaction_batch: txhash_list size: {} / raw_transactions_cache size: {} / # getrawtransaction calls: {}".format(
-        len(txhash_list), len(raw_transactions_cache), len(payload)))
+    # _logger.debug("getrawtransaction_batch: txhash_list size: {} / raw_transactions_cache size: {} / # getrawtransaction calls: {}".format(
+    #     len(txhash_list), len(raw_transactions_cache), len(payload)))
 
     # populate cache
     if len(payload) > 0:

--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -1424,6 +1424,8 @@ def follow(db):
     block_count = backend.getblockcount()   # TODO: Need retry logic
     if block_index <= block_count - 2000:
         prefetcher.start_all(NUM_PREFETCHER_THREADS)
+    else:
+        logger.debug('Not starting Prefetcher because we\'re not far enough behind.')
 
     # Get index of last transaction.
     tx_index = get_next_tx_index(db)
@@ -1453,7 +1455,7 @@ def follow(db):
 
         # Stop Prefetcher thread as we get close to today.
         if block_index >= block_count - 100:
-            prefetcher.stop_all(NUM_PREFETCHER_THREADS)
+            prefetcher.stop_all()
 
         # Get new blocks.
         if block_index <= block_count:

--- a/counterpartylib/lib/blocks.py
+++ b/counterpartylib/lib/blocks.py
@@ -46,7 +46,7 @@ from .kickstart.utils import ib2h
 from .exceptions import DecodeError, BTCOnlyError
 
 from counterpartylib.lib import prefetcher
-NUM_PREFETCHER_THREADS = 5
+NUM_PREFETCHER_THREADS = 10
 
 # Order matters for FOREIGN KEY constraints.
 TABLES = ['credits', 'debits', 'messages'] + \
@@ -1149,6 +1149,7 @@ def list_tx(db, block_hash, block_index, block_time, tx_hash, tx_index, tx_hex=N
 
     # Get the important details about each transaction.
     if tx_hex is None:
+        logging.warning("tx_hex is None")
         tx_hex = backend.getrawtransaction(tx_hash) # TODO: This is the call that is stalling the process the most
 
     source, destination, btc_amount, fee, data, decoded_tx = get_tx_info(tx_hex, db=db, block_parser=block_parser, block_index=block_index)

--- a/counterpartylib/lib/prefetcher.py
+++ b/counterpartylib/lib/prefetcher.py
@@ -43,7 +43,7 @@ class Prefetcher(threading.Thread):
 
             BLOCKCHAIN_CACHE[self.fetch_block_index] = None
 
-            #logger.debug('Fetching block {} with Prefetcher thread {}.'.format(self.fetch_block_index, self.thread_index))
+            logger.debug('Fetching block {} with Prefetcher thread {}.'.format(self.fetch_block_index, self.thread_index))
             block_hash = backend.getblockhash(self.fetch_block_index)
             block = backend.getblock(block_hash)
             txhash_list, raw_transactions = backend.get_tx_list(block)
@@ -92,8 +92,3 @@ def start_all(num_prefetcher_threads):
 def stop_all():
     for prefetcher_thread in PREFETCHER_THREADS:
         prefetcher_thread.stop_event.set()
-
-
-
-
-

--- a/counterpartylib/lib/prefetcher.py
+++ b/counterpartylib/lib/prefetcher.py
@@ -61,14 +61,14 @@ class Prefetcher(threading.Thread):
 
                 print(ctx.vin)
                 for vin in ctx.vin:
-                    print(vin)
-                    # vin_tx = backend.getrawtransaction(ib2h(vin.prevout.hash), block_index=self.fetch_block_index - 1)
                     try:
-                        vin_tx = backend.getrawtransaction(ib2h(vin.prevout.hash))
+                        # vin_tx = backend.getrawtransaction(ib2h(vin.prevout.hash), block_index=self.fetch_block_index - 1)
+                        vin_tx_hex = backend.getrawtransaction(ib2h(vin.prevout.hash))
                     except backend.addrindexrs.BackendRPCError:
                         continue
-                    vin_ctx = backend.deserialize(vin_tx)
 
+                    vin_ctx = backend.deserialize(vin_tx_hex)
+                    print(vin_ctx)
                     for vout in vin_ctx.vout:
                         asm = script.get_asm(vout.scriptPubKey)
                         if len(asm) == 5 and asm[0] == 'OP_DUP' and asm[1] == 'OP_HASH160' and asm[3] == 'OP_EQUALVERIFY' and asm[4] == 'OP_CHECKSIG':

--- a/counterpartylib/lib/prefetcher.py
+++ b/counterpartylib/lib/prefetcher.py
@@ -58,23 +58,22 @@ class Prefetcher(threading.Thread):
             for tx_hash in txhash_list:
                 tx_hex = raw_transactions[tx_hash]
                 ctx = backend.deserialize(tx_hex)
+                if ctx.is_coinbase():
+                    continue
 
-                print(ctx.vin)
                 for vin in ctx.vin:
                     try:
-                        # vin_tx = backend.getrawtransaction(ib2h(vin.prevout.hash), block_index=self.fetch_block_index - 1)
-                        vin_tx_hex = backend.getrawtransaction(ib2h(vin.prevout.hash))
+                        vin_tx = backend.getrawtransaction(ib2h(vin.prevout.hash))
                     except backend.addrindexrs.BackendRPCError:
                         continue
-
-                    vin_ctx = backend.deserialize(vin_tx_hex)
-                    print(vin_ctx)
-                    for vout in vin_ctx.vout:
-                        asm = script.get_asm(vout.scriptPubKey)
-                        if len(asm) == 5 and asm[0] == 'OP_DUP' and asm[1] == 'OP_HASH160' and asm[3] == 'OP_EQUALVERIFY' and asm[4] == 'OP_CHECKSIG':
-                            pubkeyhash = asm[2]
-                            pubkey = vin.scriptSig[1]   # TODO: integer
-                            print(pubkeyhash, pubkey)   # TODO
+                    vin_ctx = backend.deserialize(vin_tx)
+                    vout = vin_ctx.vout[vin.prevout.n]
+                    asm = script.get_asm(vout.scriptPubKey)
+                    if len(asm) == 5 and asm[0] == 'OP_DUP' and asm[1] == 'OP_HASH160' and asm[3] == 'OP_EQUALVERIFY' and asm[4] == 'OP_CHECKSIG':
+                        pubkeyhash = asm[2]
+                        pubkey = script.get_asm(vin.scriptSig)[1]
+                        assert pubkeyhash == script.hash160(pubkey)
+                        print(pubkeyhash, script.hash160(pubkey))
 
             self.fetch_block_index += self.num_threads
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ bitstring==4.1.4
 Werkzeug==3.0.1
 itsdangerous==2.1.2
 plyvel==1.5.1
+rocksdb==0.7.0


### PR DESCRIPTION
See #1373 

**TODO**
* [ ] Figure out how to make the blockchain cache and the address index gel together.
* [ ] If the pre-fetcher threads fall behind the `follow()` process, have them jump ahead?
* [ ] Set up proper DB initialization logic, with support for mainnet, testnet, etc.
* [ ] Ensure that transactions are never missed. (For now, we're just storing a block index in RocksDB if its transactions have been indexed, for instance if a thread dies; we should have a check to make sure that holes are filled.)
* [ ] Get the rest of the codebase to use this and not `addrindexrs`.
* [ ] Tests!