### PR TITLE
Use 'pycoin_rs' for base58 encoding and decoding

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,6 @@ jobs:
           command: |
             pip install --upgrade pip
             pip install hatch
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
 
       - persist_to_workspace:
           root: ~/
@@ -36,6 +34,8 @@ jobs:
       - run:
           name: "Run tests"
           command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
             mkdir test-results
             hatch run pytest --junitxml=test-results/junit.xml --verbose --cov-config=.coveragerc --cov-report=term-missing --cov=./ counterpartylib
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ jobs:
             pip install --upgrade pip
             pip install hatch
             curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
 
       - persist_to_workspace:
           root: ~/

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ jobs:
           command: |
             pip install --upgrade pip
             pip install hatch
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
 
       - persist_to_workspace:
           root: ~/

--- a/counterpartylib/test/fixtures/vectors.py
+++ b/counterpartylib/test/fixtures/vectors.py
@@ -3821,7 +3821,7 @@ UNITTEST_VECTOR = {
         }, {
             'comment': 'invalid bitcoin address: bad checksum',
             'in': ('mnMrocns5kBjPZxRxXb5A1gx7gAoRZWPP7',),
-            'error': (script.Base58ChecksumError, 'Checksum mismatch: 0x00285aa2 ≠ 0x00285aa1')
+            'error': (script.Base58Error, 'invalid base58 string')
         }, {
             'comment': 'valid multi‐sig',
             'in': ('1_mnMrocns5kBjPZxRxXb5A1gx7gAoRZWPP6_mnMrocns5kBjPZxRxXb5A1gx7gAoRZWPP6_2',),
@@ -3918,11 +3918,11 @@ UNITTEST_VECTOR = {
         }, {
             'comment': 'wrong version byte',
             'in': ('26UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM', b'\x00'),
-            'error': (script.VersionByteError, 'incorrect version byte')
+            'error': (script.Base58Error, 'invalid base58 string')
         }, {
             'comment': 'invalid mainnet bitcoin address: bad checksum',
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvN', b'\x00'),
-            'error': (script.Base58ChecksumError, 'Checksum mismatch: 0xd61967f7 ≠ 0xd61967f6')
+            'error': (script.Base58Error, 'invalid base58 string')
         }, {
             'comment': 'valid testnet bitcoin address that we use in many tests',
             'in': (ADDR[0], b'\x6f'),
@@ -3930,7 +3930,7 @@ UNITTEST_VECTOR = {
         }, {
             'comment': 'invalid mainnet bitcoin address: invalid character',
             'in': ('16UwLL9Risc3QfPqBUvKofHmBQ7wMtjv0', b'\x00'),
-            'error': (script.Base58Error, "Not a valid Base58 character: ‘0’")
+            'error': (script.Base58Error, "invalid base58 string")
         }],
         # base58_decode is the raw decoding, we use the test cases from base58_check_decode
         'base58_decode': [{

--- a/counterpartylib/test/pycoin_rs_test.py
+++ b/counterpartylib/test/pycoin_rs_test.py
@@ -1,0 +1,46 @@
+import time
+
+from counterpartylib.lib import config
+from counterpartylib.lib.script import (
+    base58_check_encode,
+    base58_check_decode, 
+    base58_check_decode_py,
+    base58_check_encode_py
+)
+
+
+def test_pycoin_rs():
+
+    vector = [
+       ("4264cfd7eb65f8cbbdba98bd9815d5461fad8d7e", config.P2SH_ADDRESSVERSION_TESTNET, "2MyJHMUenMWonC35Yi6PHC7i2tkS7PuomCy"),
+       ("641327ad1b3abc18cb6f1650a225f49a47764c22", config.ADDRESSVERSION_TESTNET, "mpe6p9ah9a6yoK57Xd2GEn8D9EonbLLkWJ"),
+       ("415354746bc11e9ef91efa85da59f0ad1df61a9d", config.ADDRESSVERSION_MAINNET, "16xQkLFxYZcGtzyGbHD7tmnaeHavD21Kw5"),
+       ("edf98b439f45eb4e3239122488cab2773296499d", config.P2SH_ADDRESSVERSION_MAINNET, "3PPK1dRAerbVZRfkh9BhA1Zxq9HrG4rRwN"),
+    ]
+
+    for (decoded, version, encoded) in vector:
+        by_python = base58_check_encode_py(decoded, version)
+        by_rust = base58_check_encode(decoded, version)
+        assert by_rust == by_python
+
+        by_python = base58_check_decode_py(encoded, version)
+        by_rust = base58_check_decode(encoded, version)
+        assert by_rust == by_python
+
+    start_time = time.time()
+    for i in range(100000):
+        for (decoded, version, encoded) in vector:
+            base58_check_encode(decoded, version)
+            base58_check_decode(encoded, version)
+    rust_duration = time.time() - start_time
+    print("rust duration for 400K encodes and 400K decodes: ", rust_duration)
+
+    start_time = time.time()
+    for i in range(100000):
+        for (decoded, version, encoded) in vector:
+            base58_check_encode_py(decoded, version)
+            base58_check_decode_py(encoded, version)
+    python_duration = time.time() - start_time
+    print("python duration for 400K encodes and 400K decodes: ", python_duration)
+
+    assert rust_duration < python_duration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ classifiers = [
     "Topic :: System :: Distributed Computing"
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.metadata.hooks.requirements_txt]
 files = ["requirements.txt"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ Werkzeug==3.0.1
 itsdangerous==2.1.2
 plyvel==1.5.1
 arc4==0.4.0
+pycoin_rs @ git+https://github.com/richardkiss/pycoin_rs


### PR DESCRIPTION
From the tests:
```
counterpartylib/test/pycoin_rs_test.py::test_pycoin_rs 
rust duration for 400K encodes and 400K decodes:  1.0097870826721191
python duration for 400K encodes and 400K decodes:  4.263357400894165
PASSED
```

![profile16](https://github.com/CounterpartyXCP/counterparty-lib/assets/4574979/1824a7cd-d92c-4033-b5bc-b1c8c04bb45c)

on this profile of a mainnet kickstart we see, without real surprise, that base58 encoding and decoding consumes a lot of time..
